### PR TITLE
Fixing close of socket in load tests

### DIFF
--- a/user_listen_test_plan.go
+++ b/user_listen_test_plan.go
@@ -98,7 +98,16 @@ func (tp *UserListenTestPlan) Start() (shouldRestart bool) {
 	go func() {
 		for {
 			select {
-			case event := <-webSocketClient.EventChannel:
+			case event, ok := <-webSocketClient.EventChannel:
+
+				if !ok {
+					if webSocketClient.ListenError != nil {
+						tp.handleError(webSocketClient.ListenError, "Socket Closed", false)
+					}
+
+					return
+				}
+
 				if event.Event != model.WEBSOCKET_EVENT_POSTED {
 					continue
 				}


### PR DESCRIPTION
**DO NOT MERGE**

This requires a fix in the `fix-block` branch to be merged into the `performance` branch first.
