### PR TITLE
add incoming count

### DIFF
--- a/cmd/loadtest/user_listen_test_plan.go
+++ b/cmd/loadtest/user_listen_test_plan.go
@@ -122,6 +122,9 @@ func (tp *UserListenTestPlan) Start() bool {
 
 						post := model.PostFromJson(strings.NewReader(event.Data["post"].(string)))
 						if post != nil {
+
+							tp.registerIncoming()
+
 							if RandomChoice(Config.ReplyPercent) {
 								message := p.RandomMessage{}.Plain()
 								message = fmt.Sprintf("reply: %v", message)
@@ -222,6 +225,14 @@ func (tp *UserListenTestPlan) registerInactive() {
 func (tp *UserListenTestPlan) registerLaunchFail() {
 	tp.activityChannel <- l.Activity{
 		Status:  l.StatusLaunchFailed,
+		ID:      tp.id,
+		Message: "Failed launch",
+	}
+}
+
+func (tp *UserListenTestPlan) registerIncoming() {
+	tp.activityChannel <- l.Activity{
+		Status:  l.StatusIncoming,
 		ID:      tp.id,
 		Message: "Failed launch",
 	}

--- a/lib/activity.go
+++ b/lib/activity.go
@@ -5,12 +5,13 @@ type Status int
 
 // StatusActive active status for activity
 const (
-	StatusActive       Status = 0
-	StatusInactive     Status = 1
-	StatusLaunching    Status = 2
-	StatusError        Status = 3
-	StatusAction       Status = 4
-	StatusLaunchFailed Status = 5
+	StatusActive Status = iota
+	StatusInactive
+	StatusLaunching
+	StatusError
+	StatusAction
+	StatusLaunchFailed
+	StatusIncoming
 )
 
 // Activity structures represent messages between user and group

--- a/lib/database.go
+++ b/lib/database.go
@@ -19,13 +19,14 @@ type Database struct {
 
 // Checkin database structure
 type Checkin struct {
-	Time        time.Time `gorethink:"time"`
-	ThreadCount int       `gorethink:"threadCount"`
-	LaunchCount int       `gorethink:"launchCount"`
-	ActiveCount int       `gorethink:"activeCount"`
-	ActionCount int       `gorethink:"actionCount"`
-	Errors      []string  `gorethink:"errors"`
-	TestID      string    `gorethink:"testID"`
+	Time          time.Time `gorethink:"time"`
+	ThreadCount   int       `gorethink:"threadCount"`
+	LaunchCount   int       `gorethink:"launchCount"`
+	ActiveCount   int       `gorethink:"activeCount"`
+	ActionCount   int       `gorethink:"actionCount"`
+	IncomingCount int       `gorethink:"incomingCount"`
+	Errors        []string  `gorethink:"errors"`
+	TestID        string    `gorethink:"testID"`
 }
 
 // CreateDBConnection to rethinkdb

--- a/lib/group_manager.go
+++ b/lib/group_manager.go
@@ -39,6 +39,7 @@ func (gm *GroupManager) Start(tp TestPlanGen, count, offset, SecRamp int) {
 	gm.Group.Kickstart(tp, count, offset, SecRamp)
 }
 
+// Stop sends a stop message to the group
 func (gm *GroupManager) Stop() {
 	defer close(stopchan)
 	gm.Info.Println("Stopping tests")
@@ -55,13 +56,14 @@ func (gm *GroupManager) startGroupCheck() {
 			return
 		default:
 			checkin := Checkin{
-				Time:        time.Now(),
-				ThreadCount: gm.Group.Total,
-				LaunchCount: gm.Group.LaunchCount,
-				ActiveCount: gm.Group.ActiveCount,
-				ActionCount: gm.Group.ActionCount,
-				Errors:      gm.Group.Errors,
-				TestID:      gm.TestID,
+				Time:          time.Now(),
+				ThreadCount:   gm.Group.Total,
+				LaunchCount:   gm.Group.LaunchCount,
+				ActiveCount:   gm.Group.ActiveCount,
+				ActionCount:   gm.Group.ActionCount,
+				IncomingCount: gm.Group.IncomingCount,
+				Errors:        gm.Group.Errors,
+				TestID:        gm.TestID,
 			}
 			if gm.Info != nil {
 				gm.logGroupCheck(checkin)
@@ -74,6 +76,7 @@ func (gm *GroupManager) startGroupCheck() {
 			}
 			gm.Group.Errors = []string{}
 			gm.Group.ActionCount = 0
+			gm.Group.IncomingCount = 0
 			time.Sleep(time.Second * 5)
 
 		}
@@ -102,9 +105,15 @@ func (gm *GroupManager) logGroupCheck(c Checkin) {
 				Total: %v
 				Launching: %v
 				Active: %v
-				Actions: %v
+				Actions: %v (%.2f a/s)
+				Incoming: %v (%.2f i/s)
 				Errors: %d`,
-		gm.Group.Total, gm.Group.LaunchCount, gm.Group.ActiveCount, gm.Group.ActionCount, len(gm.Group.Errors))
+		gm.Group.Total,
+		gm.Group.LaunchCount,
+		gm.Group.ActiveCount,
+		gm.Group.ActionCount, float32(gm.Group.ActionCount)/5.0,
+		gm.Group.IncomingCount, float32(gm.Group.IncomingCount)/5.0,
+		len(gm.Group.Errors))
 }
 
 func (gm *GroupManager) logErrors(errors []string) {

--- a/lib/thread.go
+++ b/lib/thread.go
@@ -29,13 +29,13 @@ func (t *Thread) Start(activityPipe chan<- Activity) {
 	shouldStart := true
 	for {
 		select {
-		case <- t.stopchan:
+		case <-t.stopchan:
 			return
 		default:
 			activityPipe <- t.started()
 			shouldStart = t.tpThread.Start()
+			activityPipe <- t.stopped()
 			if !shouldStart {
-				activityPipe <- t.stopped()
 				return
 			}
 		}


### PR DESCRIPTION
Fairly standard change, just added a new activity and using it only in the listen test. Also sending to db for later usage. Modified log statements to show the per second count because math is hard.

One subtle change. Moved `activityPipe <- t.stopped()` outside the shouldRestart check. Josh had shown me many cases of the activeCount getting higher than the total count. I believe the reason for this, is that stopped signal wasn't getting sent when a thread was not restarting. So the active count had zombie counts in it. In my test, it seemed to work, but this may not be 100% correct.
