### PR TITLE
fix retry logic

### DIFF
--- a/cmd/loadtest/user_entity_websocket_listener.go
+++ b/cmd/loadtest/user_entity_websocket_listener.go
@@ -61,15 +61,16 @@ func (me *UserEntityWebsocketListener) Start() {
 							continue
 						}
 						me.WebSocketClient.Listen()
-						websocketRetryCount++
-						continue
+						break
 					}
 				} else {
 					me.SendStatusFailedActive(nil, "Websocket disconneced. No Retry.")
 					return
 				}
 			}
-			me.SendStatusActionRecieve("Recieved websocket event: " + event.Event)
+			if event != nil {
+				me.SendStatusActionRecieve("Recieved websocket event: " + event.Event)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The loop was using continue in all cases, and would retry until there was an error 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1369b47]

goroutine 1 [running]:
github.com/mattermost/mattermost-load-test/loadtestconfig.(*ServerState).GetUserIds(0x0, 0xc4200e9c50, 0x1, 0x1)
	/Users/dchristopher/gocode/src/github.com/mattermost/mattermost-load-test/loadtestconfig/server_state.go:62 +0x37
main.loginUsers(0xc42018eeb0)
	/Users/dchristopher/gocode/src/github.com/mattermost/mattermost-load-test/cmd/mmanage/mmanage.go:88 +0xe0
main.loginCmd(0xc420085200, 0x17d1128, 0x0, 0x0)
	/Users/dchristopher/gocode/src/github.com/mattermost/mattermost-load-test/cmd/mmanage/mmanage.go:80 +0x2f
github.com/mattermost/mattermost-load-test/vendor/github.com/spf13/cobra.(*Command).execute(0xc420085200, 0x17d1128, 0x0, 0x0, 0xc420085200, 0x17d1128)
	/Users/dchristopher/gocode/src/github.com/mattermost/mattermost-load-test/vendor/github.com/spf13/cobra/command.go:648 +0x231
github.com/mattermost/mattermost-load-test/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420085b00, 0xc4200e9f78, 0xc420131501, 0xc420085b00)
	/Users/dchristopher/gocode/src/github.com/mattermost/mattermost-load-test/vendor/github.com/spf13/cobra/command.go:734 +0x339
github.com/mattermost/mattermost-load-test/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420085b00, 0xc4200e9f58, 0x4)
	/Users/dchristopher/gocode/src/github.com/mattermost/mattermost-load-test/vendor/github.com/spf13/cobra/command.go:693 +0x2b
main.main()
	/Users/dchristopher/gocode/src/github.com/mattermost/mattermost-load-test/cmd/mmanage/mmanage.go:48 +0x399
```