### PR TITLE
configure ReplyChance=0.3 by default

### DIFF
--- a/loadtestconfig.json
+++ b/loadtestconfig.json
@@ -22,6 +22,7 @@
         "NumUsers": 1000,
         "NumPosts": 20000000,
         "PostTimeRange": 2600000,
+        "ReplyChance": 0.3,
         "PercentHighVolumeTeams": 0.2,
         "PercentMidVolumeTeams": 0.5,
         "PercentLowVolumeTeams": 0.3,


### PR DESCRIPTION
At first I thought the load test didn't support replying to posts, but then I realized `ReplyChance` just wasn't configured. Changed to `0.3` to match discussion with @crspeller.