### PR TITLE
Fix load test instance selection, coordinate randomness

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -366,6 +366,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ac5a759da3b2a995f7082c2a75be375b90a9408568a25d1f813872d4bf02cc6e"
+  inputs-digest = "63c7961f1bea499ea577278b8b2080b684d5b274d4920f8389a39709259d3b08"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,9 +83,5 @@
   name = "github.com/lib/pq"
 
 [[constraint]]
-  name = "github.com/jinzhu/gorm"
-  version = "1.9.1"
-
-[[constraint]]
   branch = "master"
   name = "github.com/jmoiron/sqlx"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ DIST_PATH=$(DIST_ROOT)/$(DIST_FOLDER_NAME)
 all: install
 
 install:
-	dep ensure
 	$(GO) install ./cmd/loadtest
 
 loadtestconfig.json:

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ install:
 	dep ensure
 	$(GO) install ./cmd/loadtest
 
-loadtestconfig: loadtestconfig.json
+loadtestconfig.json:
 	cp loadtestconfig.default.json loadtestconfig.json
 
-package: loadtestconfig install
+package: loadtestconfig.json install
 	rm -rf $(DIST_ROOT)
 	mkdir -p $(DIST_PATH)/bin
 

--- a/loadtest/client.go
+++ b/loadtest/client.go
@@ -21,9 +21,9 @@ func newClientFromToken(token string, serverUrl string) *model.Client4 {
 	return client
 }
 
-func loginAsUsers(cfg *LoadTestConfig, entityStartNum int) []string {
+func loginAsUsers(cfg *LoadTestConfig, entityStartNum int, seed int64) []string {
 	tokens := make([]string, cfg.UserEntitiesConfiguration.NumActiveEntities)
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewSource(seed))
 	order := r.Perm(cfg.LoadtestEnviromentConfig.NumUsers)
 
 	ThreadSplit(cfg.UserEntitiesConfiguration.NumActiveEntities, runtime.GOMAXPROCS(0)*2, PrintCounter, func(i int) {
@@ -33,8 +33,6 @@ func loginAsUsers(cfg *LoadTestConfig, entityStartNum int) []string {
 		client := model.NewAPIv4Client(cfg.ConnectionConfiguration.ServerURL)
 
 		// Random selection if picked.
-		// TODO: Synchronize random selection across multiple loadtest instances by using
-		// a common seed.
 		if cfg.UserEntitiesConfiguration.RandomizeEntitySelection {
 			userNum = order[entityNum]
 		}

--- a/loadtest/instance.go
+++ b/loadtest/instance.go
@@ -46,16 +46,17 @@ func insertInstance(db *sqlx.DB, id string, now time.Time) (int, error) {
 		    SELECT 
 			CASE 
 			    WHEN li_lower.Idx IS NULL AND li.Idx > 0 THEN li.Idx - 1
-			    ELSE li.Idx + 1
+			    WHEN li_higher.Idx IS NULL THEN li.Idx + 1
+			    ELSE NULL
 			END
 		    FROM 
 			LoadtestInstances li 
 		    LEFT JOIN
-			LoadtestInstances li_lower ON ( li_lower.Idx = li.Idx - 1)
+			LoadtestInstances li_lower ON ( li_lower.Idx = li.Idx - 1 )
 		    LEFT JOIN
-			LoadtestInstances li_higher ON ( li_higher.Idx = li.Idx + 1)
+			LoadtestInstances li_higher ON ( li_higher.Idx = li.Idx + 1 )
 		    WHERE
-			li_lower.Id IS NULL
+			li.Idx > 0 AND li_lower.Id IS NULL
 		     OR li_higher.Id IS NULL
 		`)
 		if err := row.Scan(&index); err != nil && err != sql.ErrNoRows {

--- a/loadtest/run.go
+++ b/loadtest/run.go
@@ -68,9 +68,10 @@ func RunTest(test *TestRun) error {
 		}
 	}()
 	cmdlog.Infof(
-		"Registered loadtest instance `%s` (Entity Start Num: %d)",
+		"Registered loadtest instance `%s` (Entity Start Num: %d, Seed: %d)",
 		loadtestInstance.Id,
 		loadtestInstance.EntityStartNum,
+		loadtestInstance.Seed,
 	)
 
 	if loadtestInstance.EntityStartNum+cfg.UserEntitiesConfiguration.NumActiveEntities > cfg.LoadtestEnviromentConfig.NumUsers {
@@ -89,7 +90,7 @@ func RunTest(test *TestRun) error {
 	}
 
 	cmdlog.Info("Logging in as users.")
-	tokens := loginAsUsers(cfg, loadtestInstance.EntityStartNum)
+	tokens := loginAsUsers(cfg, loadtestInstance.EntityStartNum, loadtestInstance.Seed)
 	if len(tokens) == 0 {
 		return fmt.Errorf("Failed to login as any users")
 	} else if len(tokens) != cfg.UserEntitiesConfiguration.NumActiveEntities {


### PR DESCRIPTION
This is a follow-up to my last PR, fixing an issue with the selection of indexes and coordinating randomness across instances. Note that the coordination is resilient to all but instance 0 restarting -- see inline comments.