### PR TITLE
Stop manually adding users to town square in bulk load

### DIFF
--- a/loadtest/bulkload.go
+++ b/loadtest/bulkload.go
@@ -267,14 +267,6 @@ func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFile
 				Weight: selectWeight,
 			})
 			usersInTeam = append(usersInTeam, userPermutation[userNum])
-
-			userTownSquareImportData := &UserChannelImportData{
-				Name:  "town-square",
-				Roles: "channel_user",
-			}
-
-			permutation := userPermutation[userNum]
-			users[permutation].Teams[len(users[permutation].Teams)-1].Channels = append(users[permutation].Teams[len(users[permutation].Teams)-1].Channels, *userTownSquareImportData)
 		}
 
 		numHighVolumeChannels := int(math.Floor(float64(len(channelsInTeam)) * config.PercentHighVolumeChannels))


### PR DESCRIPTION
Originally the bulk load import was not adding users to town square unless there was an entry for it in the bulk load JSON file. Ever since https://github.com/mattermost/mattermost-server/commit/c158e9a5a0f776dcf19ad8b9e38e83a1f51dd918, however, that's no longer the case and the bulk importing takes care of adding users to town square. This removes adding users to town square in the bulk load JSON and prevents the tool from trying to add users to town square twice.