### PR TITLE
Use mlog to print thread splitting numbers

### DIFF
--- a/loadtest/thread_split.go
+++ b/loadtest/thread_split.go
@@ -6,6 +6,8 @@ package loadtest
 import (
 	"fmt"
 	"sync"
+
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 func PrintCounter(counter chan int, total int) {
@@ -20,7 +22,7 @@ func PrintCounter(counter chan int, total int) {
 			}
 
 			i = i + 1
-			print(fmt.Sprintf("\r %v/%v", i, total))
+			mlog.Info(fmt.Sprintf("\r %v/%v", i, total))
 			if i == total {
 				return
 			}


### PR DESCRIPTION
Having it print regularly was causing 1/1000, 2/1000, etc. to be captured in the ltops tool results, causing parsing issues with ltparse:

```
FATA[0000] failed to decode: json: cannot unmarshal number into Go value of type map[string]interface {} 
```