### PR TITLE
Preamble for load test profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ See https://kubernetes.io/docs/setup/pick-right-solution/ for more options.
 
 1. Set up a cluster:
 ```
-ltops create --name myloadtestcluster --type kubernetes --app-count 1 --db-count 1 --loadtest-count 1
+ltops create --name myloadtestcluster --type kubernetes
 ```
 
 2. Deploy and configure the helm chart:
 ```
-ltops deploy -c myloadtestcluster --license ~/mylicence.mattermost-license
+ltops deploy -c myloadtestcluster --license ~/mylicence.mattermost-license --users 5000
 ```
 
 ### Terraform

--- a/cmd/ltops/deploy.go
+++ b/cmd/ltops/deploy.go
@@ -79,7 +79,7 @@ func init() {
 
 	deploy.Flags().StringP("loadtests", "t", "", "the loadtests package to use (required for terraform)")
 
-	deploy.Flags().IntP("users", "u", 0, "the number of active users to configure the load test to run with (required for kubernetes)")
+	deploy.Flags().IntP("users", "u", 0, "number of active users in the load test (required for kubernetes)")
 
 	rootCmd.AddCommand(deploy)
 }

--- a/cmd/ltops/deploy.go
+++ b/cmd/ltops/deploy.go
@@ -57,7 +57,7 @@ var deploy = &cobra.Command{
 		}
 
 		// TODO: stop hard-coding and add flag when we have multiple profiles
-		deployOptions.Profile = kubernetes.PROFILE_STANDARD
+		deployOptions.Profile = ltops.PROFILE_STANDARD
 
 		err = cluster.Deploy(deployOptions)
 		if err != nil {

--- a/cmd/ltops/load.go
+++ b/cmd/ltops/load.go
@@ -62,11 +62,9 @@ func (c *ClusterJson) GetCluster() (ltops.Cluster, error) {
 			return nil, err
 		}
 
-		if len(cluster.Release()) > 0 {
-			err = cluster.Connect()
-			if err != nil {
-				return nil, err
-			}
+		err = cluster.Connect()
+		if err != nil {
+			return nil, err
 		}
 
 		return cluster, nil

--- a/kubernetes/chart_config.go
+++ b/kubernetes/chart_config.go
@@ -1,0 +1,139 @@
+package kubernetes
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type ChartConfig struct {
+	Global   *GlobalConfig   `yaml:"global"`
+	MySQLHA  *MySQLHAConfig  `yaml:"mysqlha"`
+	App      *AppConfig      `yaml:"mattermost-app"`
+	Loadtest *LoadtestConfig `yaml:"mattermost-loadtest"`
+	Proxy    *ProxyConfig    `yaml:"nginx-ingress"`
+}
+
+type GlobalConfig struct {
+	SiteURL           string          `yaml:"siteUrl"`
+	MattermostLicense string          `yaml:"mattermostLicense"`
+	Features          *FeaturesConfig `yaml:"features"`
+}
+
+type FeaturesConfig struct {
+	LoadTest *LoadTestFeature `yaml:"loadTest"`
+	Grafanaa *GrafanaFeature  `yaml:"grafana"`
+}
+
+type LoadTestFeature struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type GrafanaFeature struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type MySQLHAConfig struct {
+	Enabled   bool              `yaml:"enabled"`
+	Options   *MySQLHAOptions   `yaml:"mysqlha"`
+	Resources *ResourcesSetting `yaml:"resources"`
+}
+
+type MySQLHAOptions struct {
+	ReplicaCount int               `yaml:"replicaCount"`
+	ConfigFiles  *MySQLConfigFiles `yaml:"configFiles"`
+}
+
+type MySQLConfigFiles struct {
+	Master string `yaml:"master.cnf"`
+	Slave  string `yaml:"slave.cnf"`
+}
+
+type AppConfig struct {
+	ReplicaCount int               `yaml:"replicaCount"`
+	Image        *ImageSetting     `yaml:"image"`
+	Resources    *ResourcesSetting `yaml:"resources"`
+}
+
+type LoadtestConfig struct {
+	ReplicaCount                      int               `yaml:"replicaCount"`
+	Image                             *ImageSetting     `yaml:"image"`
+	Resources                         *ResourcesSetting `yaml:"resources"`
+	NumTeams                          int               `yaml:"numTeams"`
+	NumChannelsPerTeam                int               `yaml:"numChannelsPerTeam"`
+	NumUsers                          int               `yaml:"numUsers"`
+	SkipBulkLoad                      bool              `yaml:"skipBulkLoad"`
+	TestLengthMinutes                 int               `yaml:"testLengthMinutes"`
+	NumActiveEntities                 int               `yaml:"numActiveEntities"`
+	ActionRateMilliseconds            int               `yaml:"actionRateMilliseconds"`
+	ActionRateMaxVarianceMilliseconds int               `yaml:"actionRateMaxVarianceMilliseconds"`
+}
+
+type ProxyConfig struct {
+	Controller *ProxyController `yaml:"controller"`
+}
+
+type ProxyController struct {
+	ReplicaCount int               `yaml:"replicaCount"`
+	Resources    *ResourcesSetting `yaml:"resources"`
+}
+
+type ImageSetting struct {
+	Tag string `yaml:"tag"`
+}
+
+type ResourcesSetting struct {
+	Limits   *ResourceSetting `yaml:"limits"`
+	Requests *ResourceSetting `yaml:"requests"`
+}
+
+type ResourceSetting struct {
+	CPU    *Quantity `yaml:"cpu"`
+	Memory *Quantity `yaml:"memory"`
+}
+
+type Quantity struct {
+	*resource.Quantity
+}
+
+func (q *Quantity) MarshalYAML() (interface{}, error) {
+	return q.String(), nil
+}
+
+func (c *ChartConfig) TotalCPURequests() *Quantity {
+	total := cpu(0)
+	for i := 0; i < c.App.ReplicaCount; i++ {
+		total.Add(*c.App.Resources.Requests.CPU.Quantity)
+	}
+	for i := 0; i < c.MySQLHA.Options.ReplicaCount; i++ {
+		total.Add(*c.MySQLHA.Resources.Requests.CPU.Quantity)
+	}
+	for i := 0; i < c.Proxy.Controller.ReplicaCount; i++ {
+		total.Add(*c.Proxy.Controller.Resources.Requests.CPU.Quantity)
+	}
+	for i := 0; i < c.Loadtest.ReplicaCount; i++ {
+		total.Add(*c.Loadtest.Resources.Requests.CPU.Quantity)
+	}
+
+	// Add two cores as buffer for other pods
+	total.Add(*cpu(2).Quantity)
+	return total
+}
+
+func (c *ChartConfig) TotalMemoryRequests() *Quantity {
+	total := memory(0)
+	for i := 0; i < c.App.ReplicaCount; i++ {
+		total.Add(*c.App.Resources.Requests.Memory.Quantity)
+	}
+	for i := 0; i < c.MySQLHA.Options.ReplicaCount; i++ {
+		total.Add(*c.MySQLHA.Resources.Requests.Memory.Quantity)
+	}
+	for i := 0; i < c.Proxy.Controller.ReplicaCount; i++ {
+		total.Add(*c.Proxy.Controller.Resources.Requests.Memory.Quantity)
+	}
+	for i := 0; i < c.Loadtest.ReplicaCount; i++ {
+		total.Add(*c.Loadtest.Resources.Requests.Memory.Quantity)
+	}
+
+	// Add two 2 GiB of memory as buffer for other pods
+	total.Add(*memory(2).Quantity)
+	return total
+}

--- a/kubernetes/cluster_profile.go
+++ b/kubernetes/cluster_profile.go
@@ -162,8 +162,7 @@ func (c *Cluster) GetHelmConfigFromProfile(profile string, users int, license st
 		getConfigFunc = getStandardConfig
 		break
 	default:
-		getConfigFunc = getStandardConfig
-		break
+		return nil, errors.New("unrecognized profile " + profile)
 	}
 
 	config := getConfigFunc(users)

--- a/kubernetes/cluster_profile.go
+++ b/kubernetes/cluster_profile.go
@@ -1,0 +1,197 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	PROFILE_STANDARD = "profile"
+)
+
+const masterMySQLConfig = `[mysqld]
+log_bin
+skip_name_resolve
+max_connections = 300
+`
+
+const slaveMySQLConfig = `[mysqld]
+super_read_only
+skip_name_resolve
+slave_parallel_workers = 100
+slave_parallel_type = LOGICAL_CLOCK
+max_connections = 300
+`
+
+func cpu(value int64) *Quantity {
+	return &Quantity{resource.NewQuantity(value, resource.DecimalSI)}
+}
+
+func memory(valueInGiB int64) *Quantity {
+	return &Quantity{resource.NewQuantity(valueInGiB*1024*1024*1024, resource.BinarySI)}
+}
+
+func getStandardConfig(users int) *ChartConfig {
+	config := &ChartConfig{
+		Global: &GlobalConfig{
+			Features: &FeaturesConfig{
+				&LoadTestFeature{Enabled: true},
+				&GrafanaFeature{Enabled: true},
+			},
+		},
+		MySQLHA: &MySQLHAConfig{
+			Enabled: true,
+			Options: &MySQLHAOptions{
+				ConfigFiles: &MySQLConfigFiles{
+					Master: masterMySQLConfig,
+					Slave:  slaveMySQLConfig,
+				},
+			},
+			Resources: &ResourcesSetting{Requests: &ResourceSetting{}},
+		},
+		App: &AppConfig{
+			Image: &ImageSetting{
+				Tag: "4.10.1",
+			},
+			Resources: &ResourcesSetting{Requests: &ResourceSetting{}},
+		},
+		Loadtest: &LoadtestConfig{
+			Image: &ImageSetting{
+				Tag: "4.10.1",
+			},
+			Resources:                         &ResourcesSetting{Requests: &ResourceSetting{}},
+			NumTeams:                          1,
+			NumChannelsPerTeam:                400,
+			NumUsers:                          users,
+			SkipBulkLoad:                      true,
+			TestLengthMinutes:                 20,
+			ActionRateMilliseconds:            240000,
+			ActionRateMaxVarianceMilliseconds: 15000,
+		},
+		Proxy: &ProxyConfig{
+			Controller: &ProxyController{
+				Resources: &ResourcesSetting{Requests: &ResourceSetting{}},
+			},
+		},
+	}
+
+	config.Loadtest.NumUsers = users
+
+	// TODO: replace with non-flubbed numbers
+	if users <= 5000 {
+		config.App.ReplicaCount = 2
+		config.App.Resources.Requests.CPU = cpu(2)
+		config.App.Resources.Requests.Memory = memory(4)
+		config.MySQLHA.Options.ReplicaCount = 2
+		config.MySQLHA.Resources.Requests.CPU = cpu(2)
+		config.MySQLHA.Resources.Requests.Memory = memory(4)
+		config.Proxy.Controller.ReplicaCount = 1
+		config.Proxy.Controller.Resources.Requests.CPU = cpu(2)
+		config.Proxy.Controller.Resources.Requests.Memory = memory(4)
+		config.Loadtest.ReplicaCount = 1
+		config.Loadtest.Resources.Requests.CPU = cpu(2)
+		config.Loadtest.Resources.Requests.Memory = memory(4)
+	} else if users <= 10000 {
+		config.App.ReplicaCount = 2
+		config.App.Resources.Requests.CPU = cpu(4)
+		config.App.Resources.Requests.Memory = memory(8)
+		config.MySQLHA.Options.ReplicaCount = 2
+		config.MySQLHA.Resources.Requests.CPU = cpu(4)
+		config.MySQLHA.Resources.Requests.Memory = memory(8)
+		config.Proxy.Controller.ReplicaCount = 2
+		config.Proxy.Controller.Resources.Requests.CPU = cpu(2)
+		config.Proxy.Controller.Resources.Requests.Memory = memory(4)
+		config.Loadtest.ReplicaCount = 2
+		config.Loadtest.Resources.Requests.CPU = cpu(2)
+		config.Loadtest.Resources.Requests.Memory = memory(4)
+	} else if users <= 20000 {
+		config.App.ReplicaCount = 4
+		config.App.Resources.Requests.CPU = cpu(4)
+		config.App.Resources.Requests.Memory = memory(8)
+		config.MySQLHA.Options.ReplicaCount = 4
+		config.MySQLHA.Resources.Requests.CPU = cpu(4)
+		config.MySQLHA.Resources.Requests.Memory = memory(16)
+		config.Proxy.Controller.ReplicaCount = 3
+		config.Proxy.Controller.Resources.Requests.CPU = cpu(2)
+		config.Proxy.Controller.Resources.Requests.Memory = memory(4)
+		config.Loadtest.ReplicaCount = 3
+		config.Loadtest.Resources.Requests.CPU = cpu(2)
+		config.Loadtest.Resources.Requests.Memory = memory(4)
+	} else if users <= 30000 {
+		config.App.ReplicaCount = 4
+		config.App.Resources.Requests.CPU = cpu(4)
+		config.App.Resources.Requests.Memory = memory(8)
+		config.MySQLHA.Options.ReplicaCount = 4
+		config.MySQLHA.Resources.Requests.CPU = cpu(4)
+		config.MySQLHA.Resources.Requests.Memory = memory(32)
+		config.Proxy.Controller.ReplicaCount = 4
+		config.Proxy.Controller.Resources.Requests.CPU = cpu(2)
+		config.Proxy.Controller.Resources.Requests.Memory = memory(4)
+		config.Loadtest.ReplicaCount = 4
+		config.Loadtest.Resources.Requests.CPU = cpu(2)
+		config.Loadtest.Resources.Requests.Memory = memory(4)
+	} else {
+		config.App.ReplicaCount = 5
+		config.App.Resources.Requests.CPU = cpu(4)
+		config.App.Resources.Requests.Memory = memory(16)
+		config.MySQLHA.Options.ReplicaCount = 6
+		config.MySQLHA.Resources.Requests.CPU = cpu(4)
+		config.MySQLHA.Resources.Requests.Memory = memory(64)
+		config.Proxy.Controller.ReplicaCount = 6
+		config.Proxy.Controller.Resources.Requests.CPU = cpu(2)
+		config.Proxy.Controller.Resources.Requests.Memory = memory(8)
+		config.Loadtest.ReplicaCount = 6
+		config.Loadtest.Resources.Requests.CPU = cpu(4)
+		config.Loadtest.Resources.Requests.Memory = memory(8)
+	}
+
+	config.Loadtest.NumActiveEntities = users / config.Loadtest.ReplicaCount
+
+	return config
+}
+
+func (c *Cluster) GetHelmConfigFromProfile(profile string, users int, license string) (*ChartConfig, error) {
+	var getConfigFunc func(int) *ChartConfig
+
+	switch profile {
+	case PROFILE_STANDARD:
+		getConfigFunc = getStandardConfig
+		break
+	default:
+		getConfigFunc = getStandardConfig
+		break
+	}
+
+	config := getConfigFunc(users)
+	config.Global.MattermostLicense = license
+
+	nodes, err := c.Kubernetes.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	totalCPUCapacity := cpu(0).Quantity
+	totalMemoryCapacity := memory(0).Quantity
+	for _, n := range nodes.Items {
+		totalCPUCapacity.Add(*n.Status.Capacity.Cpu())
+		totalMemoryCapacity.Add(*n.Status.Capacity.Memory())
+	}
+
+	totalCPURequests := config.TotalCPURequests()
+	if totalCPUCapacity.Cmp(*totalCPURequests.Quantity) == -1 {
+		return nil, errors.New(fmt.Sprintf("not enough cpu capacity in kubernetes cluster, capacity=%v cores, required=%v cores", totalCPUCapacity, totalCPURequests))
+	}
+
+	totalMemoryRequests := config.TotalMemoryRequests()
+	if totalMemoryCapacity.Cmp(*totalMemoryRequests.Quantity) == -1 {
+		return nil, errors.New(fmt.Sprintf("not enough memory capacity in kubernetes cluster, capacity=%v, required=%v", totalMemoryCapacity, totalMemoryRequests))
+	}
+
+	log.Info(fmt.Sprintf("profile %v with %v users requests %v cores and %v memory on the cluster", profile, users, totalCPURequests, totalMemoryRequests))
+
+	return config, nil
+}

--- a/kubernetes/cluster_profile.go
+++ b/kubernetes/cluster_profile.go
@@ -3,14 +3,11 @@ package kubernetes
 import (
 	"fmt"
 
+	"github.com/mattermost/mattermost-load-test/ltops"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	PROFILE_STANDARD = "profile"
 )
 
 const masterMySQLConfig = `[mysqld]
@@ -158,7 +155,7 @@ func (c *Cluster) GetHelmConfigFromProfile(profile string, users int, license st
 	var getConfigFunc func(int) *ChartConfig
 
 	switch profile {
-	case PROFILE_STANDARD:
+	case ltops.PROFILE_STANDARD:
 		getConfigFunc = getStandardConfig
 		break
 	default:

--- a/ltops/cluster.go
+++ b/ltops/cluster.go
@@ -51,11 +51,8 @@ type Cluster interface {
 	// Returns a count of DB instances
 	DBInstanceCount() int
 
-	// Deploys a mattermost package to the cluster. mattermostFile can be disk file or URL.
-	DeployMattermost(mattermostFile string, licenceFile string) error
-
-	// Deploys a loadtest package to the cluster. loadtestsFile can be disk file or URL.
-	DeployLoadtests(loadtestsFile string) error
+	// Deploys a load test cluster.
+	Deploy(options *DeployOptions) error
 
 	// Runs a loadtest
 	Loadtest(resultsOutput io.Writer) error

--- a/ltops/deploy.go
+++ b/ltops/deploy.go
@@ -1,0 +1,10 @@
+package ltops
+
+// DeployOptions defines the possible options when deploying a Mattermost load test cluster.
+type DeployOptions struct {
+	MattermostBinaryFile string // file path or URL to Mattermost binary to use
+	LicenseFile          string // file path or URL to Mattermost enterprise license
+	LoadTestBinaryFile   string // file path or URL to load test agent binary
+	Profile              string // the profile to load test
+	Users                int    // the number of active users to simulate
+}

--- a/ltops/profile.go
+++ b/ltops/profile.go
@@ -1,0 +1,5 @@
+package ltops
+
+const (
+	PROFILE_STANDARD = "standard"
+)

--- a/terraform/cluster_deploy.go
+++ b/terraform/cluster_deploy.go
@@ -19,6 +19,14 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+func (c *Cluster) Deploy(options *ltops.DeployOptions) error {
+	if err := c.DeployMattermost(options.MattermostBinaryFile, options.LicenseFile); err != nil {
+		return err
+	}
+
+	return c.DeployLoadtests(options.LoadTestBinaryFile)
+}
+
 func (c *Cluster) DeployMattermost(mattermostDistLocation string, licenceFileLocation string) error {
 	appInstanceAddrs, err := c.GetAppInstancesAddrs()
 	if err != nil || len(appInstanceAddrs) <= 0 {


### PR DESCRIPTION
This PR does the following:
* Refactoring and cleaning up of ltops files to make supporting profiles easier
* Added something quick for a basic profile with different user levels
* When deploying a profile, ltops will check if your kubernetes cluster has enough cpu/memory capacity and error out if it doesn't
* Adds proxy and resource configuration to the helm config

Let me know what you guys think. I didn't put a ton of thought into the architecture, just wanted to get something working.

Based on #76 