### PR TITLE
Add post loading, bulk load skipping, helm config specifying and more to ltops/kubes

### DIFF
--- a/cmd/ltops/deploy.go
+++ b/cmd/ltops/deploy.go
@@ -23,6 +23,7 @@ var deploy = &cobra.Command{
 		deployOptions.MattermostBinaryFile, _ = cmd.Flags().GetString("mattermost")
 		deployOptions.LoadTestBinaryFile, _ = cmd.Flags().GetString("loadtests")
 		deployOptions.Users, _ = cmd.Flags().GetInt("users")
+		deployOptions.HelmConfigFile, _ = cmd.Flags().GetString("helm-config")
 
 		workingDir, err := defaultWorkingDirectory()
 		if err != nil {
@@ -51,8 +52,8 @@ var deploy = &cobra.Command{
 			if len(deployOptions.LoadTestBinaryFile) > 0 {
 				return errors.New("flag \"loadtests\" not supported for type " + cluster.Type())
 			}
-			if deployOptions.Users == 0 {
-				return errors.New("required flag \"users\" not set")
+			if deployOptions.Users == 0 && len(deployOptions.HelmConfigFile) == 0 {
+				return errors.New("one of flags \"users\" or \"helm-config\" must be set")
 			}
 		}
 
@@ -79,7 +80,9 @@ func init() {
 
 	deploy.Flags().StringP("loadtests", "t", "", "the loadtests package to use (required for terraform)")
 
-	deploy.Flags().IntP("users", "u", 0, "number of active users in the load test (required for kubernetes)")
+	deploy.Flags().IntP("users", "u", 0, "number of active users in the load test (used for kubernetes)")
+
+	deploy.Flags().StringP("helm-config", "f", "", "custom helm configuration to use (used for kubernetes)")
 
 	rootCmd.AddCommand(deploy)
 }

--- a/cmd/ltops/loadtest.go
+++ b/cmd/ltops/loadtest.go
@@ -3,6 +3,8 @@ package main
 import (
 	"path/filepath"
 
+	"github.com/mattermost/mattermost-load-test/ltops"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +13,10 @@ var loadTest = &cobra.Command{
 	Use:   "loadtest -- [args...]",
 	Short: "Runs a mattermost-load-test command against the given cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		loadtestOptions := &ltops.LoadTestOptions{}
 		clusterName, _ := cmd.Flags().GetString("cluster")
+		loadtestOptions.ForceBulkLoad, _ = cmd.Flags().GetBool("force-bulk-load")
+
 		//config, _ := cmd.Flags().GetString("config")
 
 		workingDir, err := defaultWorkingDirectory()
@@ -24,13 +29,15 @@ var loadTest = &cobra.Command{
 			return errors.Wrap(err, "Couldn't load cluster")
 		}
 
-		return cluster.Loadtest(nil)
+		return cluster.Loadtest(loadtestOptions)
 	},
 }
 
 func init() {
 	loadTest.Flags().StringP("cluster", "c", "", "cluster name (required)")
 	loadTest.MarkFlagRequired("cluster")
+
+	loadTest.Flags().BoolP("force-bulk-load", "", false, "force bulk load even if bulk loading already complete")
 
 	// TODO: Implement
 	//loadTest.Flags().StringP("config", "f", "", "a config file to use instead of the default (the ConnectionConfiguration section is mostly ignored)")

--- a/cmd/ltops/status.go
+++ b/cmd/ltops/status.go
@@ -50,6 +50,8 @@ SiteURL: %v
 Metrics: %v
 DBConnectionString: %v
 RR0ConnectionString: %v
+Load Test Profile: %v w/ %v users
+Bulk Loaded Data: %v
 Instances:
 	APP:    %v
 	DB:     %v
@@ -84,6 +86,9 @@ func printStatusForCluster(cluster ltops.Cluster) {
 		metrics,
 		dbConnectionString,
 		rrConnnectionString,
+		cluster.Configuration().Profile,
+		cluster.Configuration().Users,
+		cluster.Configuration().BulkLoadComplete,
 		len(app),
 		cluster.DBInstanceCount(),
 		len(proxy),

--- a/kubernetes/chart_config.go
+++ b/kubernetes/chart_config.go
@@ -20,7 +20,7 @@ type GlobalConfig struct {
 
 type FeaturesConfig struct {
 	LoadTest *LoadTestFeature `yaml:"loadTest"`
-	Grafanaa *GrafanaFeature  `yaml:"grafana"`
+	Grafana  *GrafanaFeature  `yaml:"grafana"`
 }
 
 type LoadTestFeature struct {
@@ -60,6 +60,8 @@ type LoadtestConfig struct {
 	NumTeams                          int               `yaml:"numTeams"`
 	NumChannelsPerTeam                int               `yaml:"numChannelsPerTeam"`
 	NumUsers                          int               `yaml:"numUsers"`
+	NumPosts                          int               `yaml:"numPosts"`
+	ReplyChance                       float32           `yaml:"replyChance"`
 	SkipBulkLoad                      bool              `yaml:"skipBulkLoad"`
 	TestLengthMinutes                 int               `yaml:"testLengthMinutes"`
 	NumActiveEntities                 int               `yaml:"numActiveEntities"`
@@ -81,7 +83,7 @@ type ImageSetting struct {
 }
 
 type ResourcesSetting struct {
-	Limits   *ResourceSetting `yaml:"limits"`
+	Limits   *ResourceSetting `yaml:"limits,omitempty"`
 	Requests *ResourceSetting `yaml:"requests"`
 }
 

--- a/kubernetes/cluster_profile.go
+++ b/kubernetes/cluster_profile.go
@@ -64,6 +64,7 @@ func getStandardConfig(users int) *ChartConfig {
 			NumTeams:                          1,
 			NumChannelsPerTeam:                400,
 			NumUsers:                          users,
+			ReplyChance:                       0.3,
 			SkipBulkLoad:                      true,
 			TestLengthMinutes:                 20,
 			ActionRateMilliseconds:            240000,
@@ -92,6 +93,7 @@ func getStandardConfig(users int) *ChartConfig {
 		config.Loadtest.ReplicaCount = 1
 		config.Loadtest.Resources.Requests.CPU = cpu(2)
 		config.Loadtest.Resources.Requests.Memory = memory(4)
+		config.Loadtest.NumPosts = 5000000
 	} else if users <= 10000 {
 		config.App.ReplicaCount = 2
 		config.App.Resources.Requests.CPU = cpu(4)
@@ -105,6 +107,7 @@ func getStandardConfig(users int) *ChartConfig {
 		config.Loadtest.ReplicaCount = 2
 		config.Loadtest.Resources.Requests.CPU = cpu(2)
 		config.Loadtest.Resources.Requests.Memory = memory(4)
+		config.Loadtest.NumPosts = 10000000
 	} else if users <= 20000 {
 		config.App.ReplicaCount = 4
 		config.App.Resources.Requests.CPU = cpu(4)
@@ -118,6 +121,7 @@ func getStandardConfig(users int) *ChartConfig {
 		config.Loadtest.ReplicaCount = 3
 		config.Loadtest.Resources.Requests.CPU = cpu(2)
 		config.Loadtest.Resources.Requests.Memory = memory(4)
+		config.Loadtest.NumPosts = 20000000
 	} else if users <= 30000 {
 		config.App.ReplicaCount = 4
 		config.App.Resources.Requests.CPU = cpu(4)
@@ -131,6 +135,7 @@ func getStandardConfig(users int) *ChartConfig {
 		config.Loadtest.ReplicaCount = 4
 		config.Loadtest.Resources.Requests.CPU = cpu(2)
 		config.Loadtest.Resources.Requests.Memory = memory(4)
+		config.Loadtest.NumPosts = 30000000
 	} else {
 		config.App.ReplicaCount = 5
 		config.App.Resources.Requests.CPU = cpu(4)
@@ -144,6 +149,7 @@ func getStandardConfig(users int) *ChartConfig {
 		config.Loadtest.ReplicaCount = 6
 		config.Loadtest.Resources.Requests.CPU = cpu(4)
 		config.Loadtest.Resources.Requests.Memory = memory(8)
+		config.Loadtest.NumPosts = 60000000
 	}
 
 	config.Loadtest.NumActiveEntities = users / config.Loadtest.ReplicaCount
@@ -187,7 +193,7 @@ func (c *Cluster) GetHelmConfigFromProfile(profile string, users int, license st
 		return nil, errors.New(fmt.Sprintf("not enough memory capacity in kubernetes cluster, capacity=%v, required=%v", totalMemoryCapacity, totalMemoryRequests))
 	}
 
-	log.Info(fmt.Sprintf("profile %v with %v users requests %v cores and %v memory on the cluster", profile, users, totalCPURequests, totalMemoryRequests))
+	log.Info(fmt.Sprintf("%v profile with %v users requests %v cores and %v memory on the cluster", profile, users, totalCPURequests, totalMemoryRequests))
 
 	return config, nil
 }

--- a/ltops/cluster.go
+++ b/ltops/cluster.go
@@ -1,7 +1,5 @@
 package ltops
 
-import "io"
-
 type ClusterConfig struct {
 	Name                  string
 	Type                  string
@@ -11,9 +9,12 @@ type ClusterConfig struct {
 	DBInstanceCount       int
 	LoadtestInstanceCount int
 	WorkingDirectory      string
+	Profile               string
+	Users                 int
+	BulkLoadComplete      bool
 }
 
-// Represents an active cluster
+// Cluster represents an active cluster
 type Cluster interface {
 	// Returns the name of the cluster
 	Name() string
@@ -51,11 +52,11 @@ type Cluster interface {
 	// Returns a count of DB instances
 	DBInstanceCount() int
 
-	// Deploys a load test cluster.
+	// Deploys a load test cluster
 	Deploy(options *DeployOptions) error
 
 	// Runs a loadtest
-	Loadtest(resultsOutput io.Writer) error
+	Loadtest(options *LoadTestOptions) error
 
 	// Destroys the cluster
 	Destroy() error

--- a/ltops/deploy.go
+++ b/ltops/deploy.go
@@ -7,4 +7,5 @@ type DeployOptions struct {
 	LoadTestBinaryFile   string // file path or URL to load test agent binary
 	Profile              string // the profile to load test
 	Users                int    // the number of active users to simulate
+	HelmConfigFile       string // path to helm chart config file
 }

--- a/ltops/loadtest.go
+++ b/ltops/loadtest.go
@@ -1,0 +1,9 @@
+package ltops
+
+import "io"
+
+// LoadTestOptions defines the possible options when starting a Mattermost load test.
+type LoadTestOptions struct {
+	ForceBulkLoad bool      // force bulk load even if previously loaded
+	ResultsWriter io.Writer // writer to write the results to
+}

--- a/terraform/cluster_loadtest.go
+++ b/terraform/cluster_loadtest.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mattermost/mattermost-load-test/ltops"
+
 	"github.com/mattermost/mattermost-load-test/sshtools"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -49,7 +51,7 @@ func (c *Cluster) loadtestInstance(addr string, resultsOutput io.Writer) error {
 	return nil
 }
 
-func (c *Cluster) Loadtest(resultsOutput io.Writer) error {
+func (c *Cluster) Loadtest(options *ltops.LoadTestOptions) error {
 	loadtestInstancesAddrs, err := c.GetLoadtestInstancesAddrs()
 	if err != nil || len(loadtestInstancesAddrs) <= 0 {
 		return errors.Wrap(err, "Unable to get loadtest instance addresses")
@@ -63,7 +65,7 @@ func (c *Cluster) Loadtest(resultsOutput io.Writer) error {
 		go func() {
 			var err error
 			if i == 0 {
-				err = c.loadtestInstance(addr, resultsOutput)
+				err = c.loadtestInstance(addr, options.ResultsWriter)
 			} else {
 				err = c.loadtestInstance(addr, nil)
 			}


### PR DESCRIPTION
Added the following to ltops w/ kubernetes:
* Loading of posts in the bulk load and different numbers of posts to the standard profile
* Automatic skipping of bulk loading if it has been previously completed (overridable with --force-bulk-load)
* Ability to specify a custom helm config file instead of using the standard profile and users flag
* Re-deploying/upgrading of the helm chart
* More status information