### PR TITLE
MM-10481 Increase status polling rate to more closely match real clients

### DIFF
--- a/loadtest/entity.go
+++ b/loadtest/entity.go
@@ -83,7 +83,7 @@ func doStatusPolling(ec *EntityConfig) {
 	}()
 	defer ec.StopWaitGroup.Done()
 
-	ticker := time.NewTicker(60 * time.Second)
+	ticker := time.NewTicker(45 * time.Second)
 	for {
 		select {
 		case <-ec.StopChannel:


### PR DESCRIPTION
Looking at the logs for pre-release every active user has a status request rate around 1-1.2 request/min at minimum, with our most active (or power) users peaking at around 1.8 requests/min. 

This updates the load test from making 1 request/min to 1.5 request/min to better represent the real activity we're seeing. 