### PR TITLE
setcap for mattermost binary in addition to platform

### DIFF
--- a/cmd/ltops/status.go
+++ b/cmd/ltops/status.go
@@ -14,7 +14,7 @@ import (
 
 var status = &cobra.Command{
 	Use:   "status",
-	Short: "Prints some status infomation on clusters you have running.",
+	Short: "Prints some status information on clusters you have running.",
 	RunE:  statusCmd,
 }
 

--- a/terraform/cluster_deploy.go
+++ b/terraform/cluster_deploy.go
@@ -366,6 +366,7 @@ func deployToAppInstance(mattermostDistribution, license io.Reader, instanceAddr
 
 	for _, cmd := range []string{
 		"sudo setcap cap_net_bind_service=+ep /opt/mattermost/bin/platform",
+		"[[ -f /opt/mattermost/bin/mattermost ]] && sudo setcap cap_net_bind_service=+ep /opt/mattermost/bin/mattermost",
 		"sudo systemctl daemon-reload",
 		"sudo systemctl restart mattermost.service",
 		"sudo systemctl enable mattermost.service",


### PR DESCRIPTION
This allows both mattermost and platform to bind to :80, fixing 5.0.0 loadtests and continuing to allow loadtests for older releases. This isn't an issue for Kubernetes, where we follow the pattern of binding to :8065 instead.