### PR TITLE
ltparse: fix --baseline handling

### DIFF
--- a/cmd/ltparse/results.go
+++ b/cmd/ltparse/results.go
@@ -48,6 +48,7 @@ func resultsCmd(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to open structured log file")
 		}
 		defer baselineFile.Close()
+		config.BaselineInput = baselineFile
 	}
 
 	if err := ltparse.ParseResults(&config); err != nil {

--- a/ltparse/results.go
+++ b/ltparse/results.go
@@ -91,7 +91,7 @@ func ParseResults(config *ResultsConfig) error {
 		}
 	case "text":
 		if len(allBaselineTimings) > 0 {
-			return errors.Wrap(err, "cannot compare to baseline using text display")
+			return errors.New("cannot compare to baseline using text display")
 		}
 		fallthrough
 	default:


### PR DESCRIPTION
Fix two issues with `ltparse --baseline`
* The baseline (comparison file) was not actually being passed to the results parser. This was likely a late regression in my changes.
* The diff output isn't supported in text mode, but I was incorrectly returning a `nil` error masking that.