### PR TITLE
install golang-go on loadtest to allow running pprofs

### DIFF
--- a/terraform/cluster_deploy.go
+++ b/terraform/cluster_deploy.go
@@ -148,6 +148,7 @@ func deployToLoadtestInstance(instanceNum int, instanceAddr string, loadtestDist
 	for _, cmd := range []string{
 		"sudo apt-get update",
 		"sudo apt-get install -y jq",
+		"sudo apt-get install -y golang-go",
 		"sudo rm -rf /home/ubuntu/mattermost-load-test",
 		"tar -xvzf /home/ubuntu/mattermost-load-test.tar.gz",
 		"sudo chmod 600 /home/ubuntu/key.pem",


### PR DESCRIPTION
I think we still need to expose these more easily outside of invoking the loadtest, but for now at least allow them to be automatically run.