### PR TITLE
Additional pprof fixes

### DIFF
--- a/terraform/cluster_deploy.go
+++ b/terraform/cluster_deploy.go
@@ -148,7 +148,9 @@ func deployToLoadtestInstance(instanceNum int, instanceAddr string, loadtestDist
 	for _, cmd := range []string{
 		"sudo apt-get update",
 		"sudo apt-get install -y jq",
-		"sudo apt-get install -y golang-go",
+		"wget https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz",
+		"sudo tar -C /usr/local -xzf go1.10.3.linux-amd64.tar.gz",
+		"sudo ln -sf /usr/local/go/bin/go /usr/bin/go",
 		"sudo rm -rf /home/ubuntu/mattermost-load-test",
 		"tar -xvzf /home/ubuntu/mattermost-load-test.tar.gz",
 		"sudo chmod 600 /home/ubuntu/key.pem",


### PR DESCRIPTION
This addresses some follow-up issues with pprofs:
* actually install go 1.10 on terraform. go 1.6 is too old to work with the pprofs our servers generate
* fix the url generated for gathering pprofs. `url.Parse` takes a plain hostname and returns an url with only a Path, which then got clobbered incorrectly
* improve error handling when invoking `go tool`

Once I get the key permissions fixes in, I'll update mattermod to get the loadtest label working again, and then probably figure out how best to actually expose pprofs for review at a later date.