### PR TITLE
avoid JSON serialization error when all API requests fail

### DIFF
--- a/loadtest/client_timing_stats.go
+++ b/loadtest/client_timing_stats.go
@@ -80,12 +80,18 @@ func (s *RouteStats) Merge(other *RouteStats) *RouteStats {
 }
 
 func (s *RouteStats) CalcResults() {
-	s.ErrorRate = float64(s.NumErrors) / float64(s.NumHits)
-	s.Max, _ = stats.Max(s.Duration)
-	s.Min, _ = stats.Min(s.Duration)
-	s.Mean, _ = stats.Mean(s.Duration)
-	s.Median, _ = stats.Median(s.Duration)
-	s.InterQuartileRange, _ = stats.InterQuartileRange(s.Duration)
+	if s.NumHits > 0 {
+		s.ErrorRate = float64(s.NumErrors) / float64(s.NumHits)
+	} else {
+		s.ErrorRate = 0
+	}
+	if len(s.Duration) > 0 {
+		s.Max, _ = stats.Max(s.Duration)
+		s.Min, _ = stats.Min(s.Duration)
+		s.Mean, _ = stats.Mean(s.Duration)
+		s.Median, _ = stats.Median(s.Duration)
+		s.InterQuartileRange, _ = stats.InterQuartileRange(s.Duration)
+	}
 }
 
 func NewClientTimingStats() *ClientTimingStats {


### PR DESCRIPTION
Since non-ok statuses are not recorded for statistics, the `Duration` field of the client timing stats can be empty even when a result was recorded. Handle this more gracefully when encoding statistics, since the stats library returns `NaN` in such cases but go's JSON encoder fails to encode same.