### PR TITLE
allow tuning *IdleConn*, with higher initial defaults

### DIFF
--- a/loadtest/client.go
+++ b/loadtest/client.go
@@ -6,6 +6,7 @@ package loadtest
 import (
 	"fmt"
 	"math/rand"
+	"net/http"
 	"runtime"
 	"strconv"
 	"time"
@@ -14,8 +15,10 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func newClientFromToken(token string, serverUrl string) *model.Client4 {
-	client := model.NewAPIv4Client(serverUrl)
+func newClientFromToken(httpClient *http.Client, token string, serverUrl string) *model.Client4 {
+	// Lifted from model.NewAPIv4Client
+	client := &model.Client4{serverUrl, serverUrl + model.API_URL_SUFFIX, httpClient, "", ""}
+
 	client.AuthToken = token
 	client.AuthType = model.HEADER_BEARER
 	return client
@@ -61,8 +64,9 @@ func loginAsUsers(cfg *LoadTestConfig, adminClient *model.Client4, entityStartNu
 	return activeTokens
 }
 
-func getAdminClient(serverURL string, adminEmail string, adminPass string, cmdrun ServerCLICommandRunner) *model.Client4 {
-	client := model.NewAPIv4Client(serverURL)
+func getAdminClient(httpClient *http.Client, serverURL string, adminEmail string, adminPass string, cmdrun ServerCLICommandRunner) *model.Client4 {
+	// Lifted from model.NewAPIv4Client
+	client := &model.Client4{serverURL, serverURL + model.API_URL_SUFFIX, httpClient, "", ""}
 
 	if success, resp := client.GetPing(); resp.Error != nil || success != "OK" {
 		mlog.Error(fmt.Sprintf("Failed to ping server at %v", serverURL))

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -31,23 +31,26 @@ type UserEntitiesConfiguration struct {
 }
 
 type ConnectionConfiguration struct {
-	ServerURL            string
-	WebsocketURL         string
-	PProfURL             string
-	DriverName           string
-	DataSource           string
-	DBEndpoint           string // deprecated
-	LocalCommands        bool
-	SSHHostnamePort      string
-	SSHUsername          string
-	SSHPassword          string
-	SSHKey               string
-	MattermostInstallDir string
-	ConfigFileLoc        string
-	AdminEmail           string
-	AdminPassword        string
-	SkipBulkload         bool
-	WaitForServerStart   bool
+	ServerURL                   string
+	WebsocketURL                string
+	PProfURL                    string
+	DriverName                  string
+	DataSource                  string
+	DBEndpoint                  string // deprecated
+	LocalCommands               bool
+	SSHHostnamePort             string
+	SSHUsername                 string
+	SSHPassword                 string
+	SSHKey                      string
+	MattermostInstallDir        string
+	ConfigFileLoc               string
+	AdminEmail                  string
+	AdminPassword               string
+	SkipBulkload                bool
+	WaitForServerStart          bool
+	MaxIdleConns                int
+	MaxIdleConnsPerHost         int
+	IdleConnTimeoutMilliseconds int
 }
 
 type ResultsConfiguration struct {
@@ -86,6 +89,9 @@ func ReadConfig() error {
 	viper.SetDefault("LogSettings.FileLevel", "INFO")
 	viper.SetDefault("LogSettings.FileJson", true)
 	viper.SetDefault("LogSettings.FileLocation", "loadtest.log")
+	viper.SetDefault("ConnectionConfiguration.MaxIdleConns", 100)
+	viper.SetDefault("ConnectionConfiguration.MaxIdleConnsPerHost", 128)
+	viper.SetDefault("ConnectionConfiguration.IdleConnTimeoutMilliseconds", 90000)
 
 	if err := viper.ReadInConfig(); err != nil {
 		return errors.Wrap(err, "unable to read configuration file")

--- a/loadtest/setup_server.go
+++ b/loadtest/setup_server.go
@@ -5,6 +5,7 @@ package loadtest
 
 import (
 	"fmt"
+	"net/http"
 
 	"time"
 
@@ -53,7 +54,7 @@ func SetupServer(cfg *LoadTestConfig) (*ServerSetupData, error) {
 		defer cmdrun.Close()
 	}
 
-	adminClient := getAdminClient(cfg.ConnectionConfiguration.ServerURL, cfg.ConnectionConfiguration.AdminEmail, cfg.ConnectionConfiguration.AdminPassword, cmdrun)
+	adminClient := getAdminClient(&http.Client{}, cfg.ConnectionConfiguration.ServerURL, cfg.ConnectionConfiguration.AdminEmail, cfg.ConnectionConfiguration.AdminPassword, cmdrun)
 	if adminClient == nil {
 		return nil, fmt.Errorf("Unable create admin client.")
 	}

--- a/loadtestconfig.default.json
+++ b/loadtestconfig.default.json
@@ -15,7 +15,10 @@
         "AdminEmail": "success+ltadmin@simulator.amazonses.com",
         "AdminPassword": "ltpassword",
         "SkipBulkload": false,
-        "WaitForServerStart": false
+        "WaitForServerStart": false,
+        "MaxIdleConns": 100,
+        "MaxIdleConnsPerHost": 128,
+        "IdleConnTimeoutMilliseconds": 90000
     },
     "LoadtestEnviromentConfig": {
         "NumTeams": 1,


### PR DESCRIPTION
This is a cherry-pick of a set of changes previously prepared for a customer during loadtesting.