### PR TITLE
Show 95th percentile, among other improvements.

### DIFF
--- a/cmd/ltparse/results.go
+++ b/cmd/ltparse/results.go
@@ -21,6 +21,7 @@ func resultsCmd(cmd *cobra.Command, args []string) error {
 	config.Aggregate, _ = cmd.Flags().GetBool("aggregate")
 	inputFilename, _ := cmd.Flags().GetString("file")
 	baselineFilename, _ := cmd.Flags().GetString("baseline")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	config.Output = os.Stdout
 
@@ -51,6 +52,8 @@ func resultsCmd(cmd *cobra.Command, args []string) error {
 		config.BaselineInput = baselineFile
 	}
 
+	config.Verbose = verbose
+
 	if err := ltparse.ParseResults(&config); err != nil {
 		return err
 	}
@@ -63,6 +66,7 @@ func init() {
 	results.Flags().StringP("display", "d", "text", "one of 'text' or 'markdown'")
 	results.Flags().BoolP("aggregate", "a", false, "aggregate all results found instead of just picking the last")
 	results.Flags().StringP("baseline", "b", "", "a file containing structured logs to which to compare results")
+	results.Flags().BoolP("verbose", "v", false, "display additional statistics")
 
 	rootCmd.AddCommand(results)
 }

--- a/loadtest/client_timing_stats.go
+++ b/loadtest/client_timing_stats.go
@@ -19,6 +19,8 @@ type RouteStatResults struct {
 	Min                float64
 	Mean               float64
 	Median             float64
+	Percentile90       float64
+	Percentile95       float64
 	InterQuartileRange float64
 }
 
@@ -33,6 +35,8 @@ type RouteStats struct {
 	Min                float64
 	Mean               float64
 	Median             float64
+	Percentile90       float64
+	Percentile95       float64
 	InterQuartileRange float64
 }
 
@@ -90,6 +94,8 @@ func (s *RouteStats) CalcResults() {
 		s.Min, _ = stats.Min(s.Duration)
 		s.Mean, _ = stats.Mean(s.Duration)
 		s.Median, _ = stats.Median(s.Duration)
+		s.Percentile90, _ = stats.Percentile(s.Duration, 90)
+		s.Percentile95, _ = stats.Percentile(s.Duration, 95)
 		s.InterQuartileRange, _ = stats.InterQuartileRange(s.Duration)
 	}
 }

--- a/loadtest/client_timing_stats.go
+++ b/loadtest/client_timing_stats.go
@@ -158,12 +158,12 @@ func (ts *ClientTimingStats) AddTimingReport(timingReport TimedRoundTripperRepor
 	ts.AddRouteSample(path, int64(timingReport.RequestDuration/time.Millisecond), timingReport.StatusCode)
 }
 
-// Score is currently the average mean of all the routes
+// Score is the average of the 95th percentile, median and interquartile range of all routes.
 func (ts *ClientTimingStats) GetScore() float64 {
 	total := 0.0
 	num := 0.0
 	for _, stats := range ts.Routes {
-		total += stats.Mean
+		total += stats.Percentile95
 		total += stats.Median
 		total += stats.InterQuartileRange
 		num += 1.0

--- a/ltparse/markdown.go
+++ b/ltparse/markdown.go
@@ -70,6 +70,8 @@ The score is the the average of the mean reponse times below.
 | Min Response Time | {{.Min}}ms |
 | Mean Response Time | {{printf "%.2f" .Mean}}ms |
 | Median Response Time | {{printf "%.2f" .Median}}ms |
+| 90th Percentile | {{printf "%.2f" .Percentile90}}ms |
+| 95th Percentile | {{printf "%.2f" .Percentile95}}ms |
 | Inter Quartile Range | {{.InterQuartileRange}} |
 `,
 	))
@@ -84,6 +86,8 @@ The score is the the average of the mean reponse times below.
 | Min Response Time | {{.Baseline.Min}}ms | {{.Actual.Min}}ms | {{compareFloat64 .Actual.Min .Baseline.Min}}ms | {{comparePercentageFloat64 .Actual.Min .Baseline.Min}} |
 | Mean Response Time | {{printf "%.2f" .Baseline.Mean}}ms | {{printf "%.2f" .Actual.Mean}}ms | {{compareFloat64 .Actual.Mean .Baseline.Mean}}ms | {{comparePercentageFloat64 .Actual.Mean .Baseline.Mean}} |
 | Median Response Time | {{printf "%.2f" .Baseline.Median}}ms | {{printf "%.2f" .Actual.Median}}ms | {{compareFloat64 .Actual.Median .Baseline.Median}}ms | {{comparePercentageFloat64 .Actual.Median .Baseline.Median}} |
+| 90th Percentile | {{printf "%.2f" .Baseline.Percentile90}}ms | {{printf "%.2f" .Actual.Percentile90}}ms | {{compareFloat64 .Actual.Percentile90 .Baseline.Percentile90}}ms | {{comparePercentageFloat64 .Actual.Percentile90 .Baseline.Percentile90}} |
+| 95th Percentile | {{printf "%.2f" .Baseline.Percentile95}}ms | {{printf "%.2f" .Actual.Percentile95}}ms | {{compareFloat64 .Actual.Percentile95 .Baseline.Percentile95}}ms | {{comparePercentageFloat64 .Actual.Percentile95 .Baseline.Percentile95}} |
 | Inter Quartile Range | {{.Baseline.InterQuartileRange}} | {{.Actual.InterQuartileRange}} | {{compareFloat64 .Actual.InterQuartileRange .Baseline.InterQuartileRange}}ms | {{comparePercentageFloat64 .Actual.InterQuartileRange .Baseline.InterQuartileRange}} |
 `,
 	))
@@ -98,6 +102,8 @@ The score is the the average of the mean reponse times below.
 | Min Response Time | - | {{.Min}}ms | - |
 | Mean Response Time | - | {{printf "%.2f" .Mean}}ms | - |
 | Median Response Time | - | {{printf "%.2f" .Median}}ms | - |
+| 90th Percentile | - | {{printf "%.2f" .Percentile90}}ms | - |
+| 95th Percentile | - | {{printf "%.2f" .Percentile95}}ms | - |
 | Inter Quartile Range | - | {{.InterQuartileRange}} | - |
 `,
 	))

--- a/ltparse/markdown.go
+++ b/ltparse/markdown.go
@@ -61,18 +61,20 @@ The score is the the average of the mean reponse times below.
 	))
 
 	singleTimingTemplate = template.Must(template.New("singleTimingTemplate").Funcs(funcMap).Parse(
-		`#### {{.Name}}
+		`#### {{.Actual.Name}}
 | Metric | Actual |
 | --- | --- |
-| Hits | {{.NumHits}} |
-| Error Rate | {{printf "%.2f%%" .ErrorRate}} |
-| Max Response Time | {{.Max}}ms |
-| Min Response Time | {{.Min}}ms |
-| Mean Response Time | {{printf "%.2f" .Mean}}ms |
-| Median Response Time | {{printf "%.2f" .Median}}ms |
-| 90th Percentile | {{printf "%.2f" .Percentile90}}ms |
-| 95th Percentile | {{printf "%.2f" .Percentile95}}ms |
-| Inter Quartile Range | {{.InterQuartileRange}} |
+| Hits | {{.Actual.NumHits}} |
+| Error Rate | {{printf "%.2f%%" .Actual.ErrorRate}} |
+| Mean Response Time | {{printf "%.2f" .Actual.Mean}}ms |
+| Median Response Time | {{printf "%.2f" .Actual.Median}}ms |
+| 95th Percentile | {{printf "%.2f" .Actual.Percentile95}}ms |
+{{if .Verbose -}}
+| 90th Percentile | {{printf "%.2f" .Actual.Percentile90}}ms |
+| Max Response Time | {{.Actual.Max}}ms |
+| Min Response Time | {{.Actual.Min}}ms |
+| Inter Quartile Range | {{.Actual.InterQuartileRange}} |
+{{end}}
 `,
 	))
 
@@ -82,13 +84,15 @@ The score is the the average of the mean reponse times below.
 | --- | --- | --- | --- | --- |
 | Hits | {{.Baseline.NumHits}} | {{.Actual.NumHits}} | {{compareInt64 .Actual.NumHits .Baseline.NumHits}} | {{comparePercentageInt64 .Actual.NumHits .Baseline.NumHits}}
 | Error Rate | {{printf "%.2f%%" .Baseline.ErrorRate }} | {{printf "%.2f%%" .Actual.ErrorRate}} | {{comparePercentageFloat64 .Actual.ErrorRate .Baseline.ErrorRate}} | {{comparePercentageFloat64 .Actual.ErrorRate .Baseline.ErrorRate}} |
-| Max Response Time | {{.Baseline.Max}}ms | {{.Actual.Max}}ms | {{compareFloat64 .Actual.Max .Baseline.Max}}ms | {{comparePercentageFloat64 .Actual.Max .Baseline.Max}} |
-| Min Response Time | {{.Baseline.Min}}ms | {{.Actual.Min}}ms | {{compareFloat64 .Actual.Min .Baseline.Min}}ms | {{comparePercentageFloat64 .Actual.Min .Baseline.Min}} |
 | Mean Response Time | {{printf "%.2f" .Baseline.Mean}}ms | {{printf "%.2f" .Actual.Mean}}ms | {{compareFloat64 .Actual.Mean .Baseline.Mean}}ms | {{comparePercentageFloat64 .Actual.Mean .Baseline.Mean}} |
 | Median Response Time | {{printf "%.2f" .Baseline.Median}}ms | {{printf "%.2f" .Actual.Median}}ms | {{compareFloat64 .Actual.Median .Baseline.Median}}ms | {{comparePercentageFloat64 .Actual.Median .Baseline.Median}} |
-| 90th Percentile | {{printf "%.2f" .Baseline.Percentile90}}ms | {{printf "%.2f" .Actual.Percentile90}}ms | {{compareFloat64 .Actual.Percentile90 .Baseline.Percentile90}}ms | {{comparePercentageFloat64 .Actual.Percentile90 .Baseline.Percentile90}} |
 | 95th Percentile | {{printf "%.2f" .Baseline.Percentile95}}ms | {{printf "%.2f" .Actual.Percentile95}}ms | {{compareFloat64 .Actual.Percentile95 .Baseline.Percentile95}}ms | {{comparePercentageFloat64 .Actual.Percentile95 .Baseline.Percentile95}} |
+{{if .Verbose -}}
+| 90th Percentile | {{printf "%.2f" .Baseline.Percentile90}}ms | {{printf "%.2f" .Actual.Percentile90}}ms | {{compareFloat64 .Actual.Percentile90 .Baseline.Percentile90}}ms | {{comparePercentageFloat64 .Actual.Percentile90 .Baseline.Percentile90}} |
+| Max Response Time | {{.Baseline.Max}}ms | {{.Actual.Max}}ms | {{compareFloat64 .Actual.Max .Baseline.Max}}ms | {{comparePercentageFloat64 .Actual.Max .Baseline.Max}} |
+| Min Response Time | {{.Baseline.Min}}ms | {{.Actual.Min}}ms | {{compareFloat64 .Actual.Min .Baseline.Min}}ms | {{comparePercentageFloat64 .Actual.Min .Baseline.Min}} |
 | Inter Quartile Range | {{.Baseline.InterQuartileRange}} | {{.Actual.InterQuartileRange}} | {{compareFloat64 .Actual.InterQuartileRange .Baseline.InterQuartileRange}}ms | {{comparePercentageFloat64 .Actual.InterQuartileRange .Baseline.InterQuartileRange}} |
+{{end}}
 `,
 	))
 
@@ -96,15 +100,17 @@ The score is the the average of the mean reponse times below.
 		`#### {{.Name}}
 | Metric | Baseline | Actual | Delta |
 | --- | --- | --- | --- |
-| Hits | - | {{.NumHits}} | - |
-| Error Rate | - | {{printf "%.2f%%" .ErrorRate}} | - |
-| Max Response Time | - | {{.Max}}ms | - |
-| Min Response Time | - | {{.Min}}ms | - |
-| Mean Response Time | - | {{printf "%.2f" .Mean}}ms | - |
-| Median Response Time | - | {{printf "%.2f" .Median}}ms | - |
-| 90th Percentile | - | {{printf "%.2f" .Percentile90}}ms | - |
-| 95th Percentile | - | {{printf "%.2f" .Percentile95}}ms | - |
-| Inter Quartile Range | - | {{.InterQuartileRange}} | - |
+| Hits | - | {{.Actual.NumHits}} | - |
+| Error Rate | - | {{printf "%.2f%%" .Actual.ErrorRate}} | - |
+| Mean Response Time | - | {{printf "%.2f" .Actual.Mean}}ms | - |
+| Median Response Time | - | {{printf "%.2f" .Actual.Median}}ms | - |
+| 95th Percentile | - | {{printf "%.2f" .Actual.Percentile95}}ms | - |
+{{if .Verbose -}}
+| 90th Percentile | - | {{printf "%.2f" .Actual.Percentile90}}ms | - |
+| Max Response Time | - | {{.Actual.Max}}ms | - |
+| Min Response Time | - | {{.Actual.Min}}ms | - |
+| Inter Quartile Range | - | {{.Actual.InterQuartileRange}} | - |
+{{end}}
 `,
 	))
 )
@@ -124,13 +130,15 @@ func sortedRoutes(routesMap map[string]*loadtest.RouteStats) []*loadtest.RouteSt
 	return routes
 }
 
-func dumpSingleTimingsMarkdown(timings *loadtest.ClientTimingStats, output io.Writer) error {
+func dumpSingleTimingsMarkdown(timings *loadtest.ClientTimingStats, output io.Writer, verbose bool) error {
 	if err := timingSummaryMarkdown.Execute(output, timings); err != nil {
 		return errors.Wrap(err, "error executing summary template")
 	}
 
 	for _, route := range sortedRoutes(timings.Routes) {
-		if err := singleTimingTemplate.Execute(output, route); err != nil {
+		data := templateData{route, nil, verbose}
+
+		if err := singleTimingTemplate.Execute(output, data); err != nil {
 			return errors.Wrap(err, "error executing route template")
 		}
 	}
@@ -138,26 +146,20 @@ func dumpSingleTimingsMarkdown(timings *loadtest.ClientTimingStats, output io.Wr
 	return nil
 }
 
-func dumpComparisonTimingsMarkdown(timings *loadtest.ClientTimingStats, baseline *loadtest.ClientTimingStats, output io.Writer) error {
+func dumpComparisonTimingsMarkdown(timings *loadtest.ClientTimingStats, baseline *loadtest.ClientTimingStats, output io.Writer, verbose bool) error {
 	if err := timingSummaryMarkdown.Execute(output, timings); err != nil {
 		return errors.Wrap(err, "error executing summary template")
 	}
 
 	for _, route := range sortedRoutes(timings.Routes) {
-		baselineRoute, ok := baseline.Routes[route.Name]
-		if !ok {
-			if err := comparisonTimingWithoutBaselineTemplate.Execute(output, route); err != nil {
+		if baselineRoute, ok := baseline.Routes[route.Name]; !ok {
+			data := templateData{route, nil, verbose}
+			if err := comparisonTimingWithoutBaselineTemplate.Execute(output, data); err != nil {
 				return errors.Wrap(err, "error executing route template")
 			}
 		} else {
-			comparison := struct {
-				Actual   *loadtest.RouteStats
-				Baseline *loadtest.RouteStats
-			}{
-				route,
-				baselineRoute,
-			}
-			if err := comparisonTimingTemplate.Execute(output, comparison); err != nil {
+			data := templateData{route, baselineRoute, verbose}
+			if err := comparisonTimingTemplate.Execute(output, data); err != nil {
 				return errors.Wrap(err, "error executing route template")
 			}
 		}
@@ -166,10 +168,10 @@ func dumpComparisonTimingsMarkdown(timings *loadtest.ClientTimingStats, baseline
 	return nil
 }
 
-func dumpTimingsMarkdown(timings *loadtest.ClientTimingStats, baselineTimings *loadtest.ClientTimingStats, output io.Writer) error {
+func dumpTimingsMarkdown(timings *loadtest.ClientTimingStats, baselineTimings *loadtest.ClientTimingStats, output io.Writer, verbose bool) error {
 	if baselineTimings == nil {
-		return dumpSingleTimingsMarkdown(timings, output)
+		return dumpSingleTimingsMarkdown(timings, output, verbose)
 	} else {
-		return dumpComparisonTimingsMarkdown(timings, baselineTimings, output)
+		return dumpComparisonTimingsMarkdown(timings, baselineTimings, output, verbose)
 	}
 }

--- a/ltparse/markdown.go
+++ b/ltparse/markdown.go
@@ -54,7 +54,7 @@ var (
 	timingSummaryMarkdown = template.Must(template.New("timingSummaryMarkdown").Parse(
 		`## Loadtest Results
 ### Score: {{printf "%.2f" .GetScore}}
-The score is the the average of the mean reponse times below.
+The score is the average of the 95th percentile, median and interquartile ranges in the routes below.
 
 ### Routes
 `,

--- a/ltparse/results.go
+++ b/ltparse/results.go
@@ -84,6 +84,11 @@ func ParseResults(config *ResultsConfig) error {
 		}
 	}
 
+	timings.CalcResults()
+	if baselineTimings != nil {
+		baselineTimings.CalcResults()
+	}
+
 	switch config.Display {
 	case "markdown":
 		if err := dumpTimingsMarkdown(timings, baselineTimings, config.Output); err != nil {

--- a/ltparse/results.go
+++ b/ltparse/results.go
@@ -16,6 +16,13 @@ type ResultsConfig struct {
 	Output        io.Writer
 	Display       string
 	Aggregate     bool
+	Verbose       bool
+}
+
+type templateData struct {
+	Actual   *loadtest.RouteStats
+	Baseline *loadtest.RouteStats
+	Verbose  bool
 }
 
 func parseTimings(input io.Reader) ([]*loadtest.ClientTimingStats, error) {
@@ -91,7 +98,7 @@ func ParseResults(config *ResultsConfig) error {
 
 	switch config.Display {
 	case "markdown":
-		if err := dumpTimingsMarkdown(timings, baselineTimings, config.Output); err != nil {
+		if err := dumpTimingsMarkdown(timings, baselineTimings, config.Output, config.Verbose); err != nil {
 			return errors.Wrap(err, "failed to dump timings")
 		}
 	case "text":
@@ -100,7 +107,7 @@ func ParseResults(config *ResultsConfig) error {
 		}
 		fallthrough
 	default:
-		if err := dumpTimingsText(timings, config.Output); err != nil {
+		if err := dumpTimingsText(timings, config.Output, config.Verbose); err != nil {
 			return errors.Wrap(err, "failed to dump timings")
 		}
 	}

--- a/ltparse/text.go
+++ b/ltparse/text.go
@@ -10,36 +10,39 @@ import (
 	"github.com/mattermost/mattermost-load-test/loadtest"
 )
 
-func dumpTimingsText(timings *loadtest.ClientTimingStats, output io.Writer) error {
-	const rates = `Total Hits: {{.NumHits}}
-Error Rate: {{percent .NumErrors .NumHits}}%
-Max Response Time: {{.Max}}ms
-Min Response Time: {{.Min}}ms
-Mean Response Time: {{printf "%.2f" .Mean}}ms
-Median Response Time: {{printf "%.2f" .Median}}ms
-90th Percentile: {{printf "%.2f" .Percentile90}}ms
-95th Percentile: {{printf "%.2f" .Percentile95}}ms
-Inter Quartile Range: {{.InterQuartileRange}}
-
+const text = `Total Hits: {{.Actual.NumHits}}
+Error Rate: {{percent .Actual.NumErrors .Actual.NumHits}}%
+Mean Response Time: {{printf "%.2f" .Actual.Mean}}ms
+Median Response Time: {{printf "%.2f" .Actual.Median}}ms
+95th Percentile: {{printf "%.2f" .Actual.Percentile95}}ms
+{{if .Verbose -}}
+90th Percentile: {{printf "%.2f" .Actual.Percentile90}}ms
+Max Response Time: {{.Actual.Max}}ms
+Min Response Time: {{.Actual.Min}}ms
+Inter Quartile Range: {{.Actual.InterQuartileRange}}
+{{end}}
 `
+
+func dumpTimingsText(timings *loadtest.ClientTimingStats, output io.Writer, verbose bool) error {
 	funcMap := template.FuncMap{
 		"percent": func(x, y int64) string {
 			return fmt.Sprintf("%.2f", float64(x)/float64(y)*100.0)
 		},
 	}
-	rateTemplate := template.Must(template.New("rates").Funcs(funcMap).Parse(rates))
+	rateTemplate := template.Must(template.New("rates").Funcs(funcMap).Parse(text))
 
 	fmt.Println("--------- Timings Report ------------")
 
 	for routeName, route := range timings.Routes {
 		fmt.Println("Route: " + routeName)
-		if err := rateTemplate.Execute(output, route); err != nil {
+		data := templateData{route, nil, verbose}
+		if err := rateTemplate.Execute(output, data); err != nil {
 			return errors.Wrap(err, "error executing template")
 		}
 	}
 
-	fmt.Printf("Score: %.2f", timings.GetScore())
-	fmt.Println("")
+	fmt.Fprintf(output, "Score: %.2f", timings.GetScore())
+	fmt.Fprintln(output, "")
 
 	return nil
 }

--- a/ltparse/text.go
+++ b/ltparse/text.go
@@ -17,6 +17,8 @@ Max Response Time: {{.Max}}ms
 Min Response Time: {{.Min}}ms
 Mean Response Time: {{printf "%.2f" .Mean}}ms
 Median Response Time: {{printf "%.2f" .Median}}ms
+90th Percentile: {{printf "%.2f" .Percentile90}}ms
+95th Percentile: {{printf "%.2f" .Percentile95}}ms
 Inter Quartile Range: {{.InterQuartileRange}}
 
 `


### PR DESCRIPTION
This set of PRs:
* adds 90th and 95th percentiles
* hides max/min/iqr/90p by default, exposed via a `--verbose` flag
* changes the score algorithm to include 95th percentile instead of mean
* adds comparison between actual and baseline scores for quick reference