### PR TITLE
MM-10486 Add opengraph POSTs to load test

### DIFF
--- a/kubernetes/chart_config.go
+++ b/kubernetes/chart_config.go
@@ -5,11 +5,20 @@ import (
 )
 
 type ChartConfig struct {
-	Global   *GlobalConfig   `yaml:"global"`
-	MySQLHA  *MySQLHAConfig  `yaml:"mysqlha"`
-	App      *AppConfig      `yaml:"mattermost-app"`
-	Loadtest *LoadtestConfig `yaml:"mattermost-loadtest"`
-	Proxy    *ProxyConfig    `yaml:"nginx-ingress"`
+	Global     *GlobalConfig     `yaml:"global"`
+	Tags       *TagsConfig       `yaml:"tags"`
+	MySQLHA    *MySQLHAConfig    `yaml:"mysqlha"`
+	App        *AppConfig        `yaml:"mattermost-app"`
+	Loadtest   *LoadtestConfig   `yaml:"mattermost-loadtest"`
+	Proxy      *ProxyConfig      `yaml:"nginx-ingress"`
+	Prometheus *PrometheusConfig `yaml:"prometheus"`
+}
+
+type TagsConfig struct {
+	Core    bool `yaml:"core"`
+	Metrics bool `yaml:"metrics"`
+	Ingress bool `yaml:"ingress"`
+	Storage bool `yaml:"storage"`
 }
 
 type GlobalConfig struct {
@@ -19,8 +28,9 @@ type GlobalConfig struct {
 }
 
 type FeaturesConfig struct {
-	LoadTest *LoadTestFeature `yaml:"loadTest"`
-	Grafana  *GrafanaFeature  `yaml:"grafana"`
+	LoadTest     *LoadTestFeature    `yaml:"loadTest"`
+	Grafana      *GrafanaFeature     `yaml:"grafana"`
+	LinkPreviews *LinkPreviewFeature `yaml:"linkPreviews"`
 }
 
 type LoadTestFeature struct {
@@ -28,6 +38,10 @@ type LoadTestFeature struct {
 }
 
 type GrafanaFeature struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type LinkPreviewFeature struct {
 	Enabled bool `yaml:"enabled"`
 }
 
@@ -62,6 +76,7 @@ type LoadtestConfig struct {
 	NumUsers                          int               `yaml:"numUsers"`
 	NumPosts                          int               `yaml:"numPosts"`
 	ReplyChance                       float32           `yaml:"replyChance"`
+	LinkPreviewChance                 float32           `yaml:"linkPreviewChance"`
 	SkipBulkLoad                      bool              `yaml:"skipBulkLoad"`
 	TestLengthMinutes                 int               `yaml:"testLengthMinutes"`
 	NumActiveEntities                 int               `yaml:"numActiveEntities"`
@@ -70,12 +85,17 @@ type LoadtestConfig struct {
 }
 
 type ProxyConfig struct {
+	Enabled    bool             `yaml:"enabled"`
 	Controller *ProxyController `yaml:"controller"`
 }
 
 type ProxyController struct {
 	ReplicaCount int               `yaml:"replicaCount"`
 	Resources    *ResourcesSetting `yaml:"resources"`
+}
+
+type PrometheusConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type ImageSetting struct {

--- a/kubernetes/cluster_profile.go
+++ b/kubernetes/cluster_profile.go
@@ -36,9 +36,16 @@ func getStandardConfig(users int) *ChartConfig {
 	config := &ChartConfig{
 		Global: &GlobalConfig{
 			Features: &FeaturesConfig{
-				&LoadTestFeature{Enabled: true},
-				&GrafanaFeature{Enabled: true},
+				LoadTest:     &LoadTestFeature{Enabled: true},
+				Grafana:      &GrafanaFeature{Enabled: true},
+				LinkPreviews: &LinkPreviewFeature{Enabled: true},
 			},
+		},
+		Tags: &TagsConfig{
+			Core:    true,
+			Metrics: true,
+			Ingress: true,
+			Storage: true,
 		},
 		MySQLHA: &MySQLHAConfig{
 			Enabled: true,
@@ -65,15 +72,20 @@ func getStandardConfig(users int) *ChartConfig {
 			NumChannelsPerTeam:                400,
 			NumUsers:                          users,
 			ReplyChance:                       0.3,
+			LinkPreviewChance:                 0.2,
 			SkipBulkLoad:                      true,
 			TestLengthMinutes:                 20,
 			ActionRateMilliseconds:            240000,
 			ActionRateMaxVarianceMilliseconds: 15000,
 		},
 		Proxy: &ProxyConfig{
+			Enabled: true,
 			Controller: &ProxyController{
 				Resources: &ResourcesSetting{Requests: &ResourceSetting{}},
 			},
+		},
+		Prometheus: &PrometheusConfig{
+			Enabled: true,
 		},
 	}
 

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -26,6 +26,7 @@ type UserEntitiesConfiguration struct {
 	EnableRequestTiming               bool
 	ChannelLinkChance                 float64
 	UploadImageChance                 float64
+	LinkPreviewChance                 float64
 	DoStatusPolling                   bool
 	RandomizeEntitySelection          bool
 }

--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -254,7 +254,6 @@ func actionGetChannel(c *EntityConfig) {
 			mlog.Error(fmt.Sprintf("Got nil posts for get posts for channel. Resp was: %#v", resp))
 			return
 		}
-		index := 0
 		for _, post := range posts.Posts {
 			if post.HasReactions {
 				if _, resp := c.Client.GetReactions(post.Id); resp.Error != nil {
@@ -275,13 +274,11 @@ func actionGetChannel(c *EntityConfig) {
 				}
 			}
 
-			// Assume a link every 5 posts
-			if index%5 == 0 {
+			if rand.Float64() < c.LoadTestConfig.UserEntitiesConfiguration.LinkPreviewChance {
 				if _, resp := c.Client.OpenGraph(OPENGRAPH_TEST_URL); resp.Error != nil {
 					mlog.Error("Unable to get open graph for url.", mlog.String("url", OPENGRAPH_TEST_URL), mlog.String("user_id", post.UserId), mlog.Err(resp.Error))
 				}
 			}
-			index++
 		}
 	}
 }
@@ -297,6 +294,7 @@ func actionPerformSearch(c *EntityConfig) {
 	if resp.Error != nil {
 		mlog.Error("Failed to search", mlog.Err(resp.Error))
 	}
+
 }
 
 func actionAutocompleteChannel(c *EntityConfig) {

--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -23,6 +23,10 @@ import (
 	"github.com/mattermost/mattermost-server/utils"
 )
 
+const (
+	OPENGRAPH_TEST_URL = "https://s3.amazonaws.com/mattermost-load-test-media/index.html"
+)
+
 type TestRun struct {
 	UserEntities []randutil.Choice
 }
@@ -250,6 +254,7 @@ func actionGetChannel(c *EntityConfig) {
 			mlog.Error(fmt.Sprintf("Got nil posts for get posts for channel. Resp was: %#v", resp))
 			return
 		}
+		index := 0
 		for _, post := range posts.Posts {
 			if post.HasReactions {
 				if _, resp := c.Client.GetReactions(post.Id); resp.Error != nil {
@@ -269,6 +274,14 @@ func actionGetChannel(c *EntityConfig) {
 					}
 				}
 			}
+
+			// Assume a link every 5 posts
+			if index%5 == 0 {
+				if _, resp := c.Client.OpenGraph(OPENGRAPH_TEST_URL); resp.Error != nil {
+					mlog.Error("Unable to get open graph for url.", mlog.String("url", OPENGRAPH_TEST_URL), mlog.String("user_id", post.UserId), mlog.Err(resp.Error))
+				}
+			}
+			index++
 		}
 	}
 }

--- a/loadtestconfig.default.json
+++ b/loadtestconfig.default.json
@@ -58,6 +58,7 @@
         "EnableRequestTiming": true,
         "ChannelLinkChance": 0.02,
         "UploadImageChance": 0.01,
+        "LinkPreviewChance": 0.2,
         "DoStatusPolling": true,
         "RandomizeEntitySelection": false
     },


### PR DESCRIPTION
I also included some updates to the ltops tool to make it work with the changes to helm chart and to also restart less pods on upgrade.