### PR TITLE
MM-10484 Add /api/v4/users/me/teams/unread to load tests

### DIFF
--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -397,6 +397,13 @@ func actionPostWebhook(c *EntityConfig) {
 	}
 }
 
+func actionGetTeamUnreads(c *EntityConfig) {
+	_, err := c.Client.GetTeamsUnreadForUser("me", "")
+	if err != nil {
+		mlog.Error("Failed to get team unreads", mlog.String("user", c.UserData.Username))
+	}
+}
+
 var posterEntity UserEntity = UserEntity{
 	Name: "Poster",
 	Actions: []randutil.Choice{
@@ -477,6 +484,10 @@ var standardUserEntity UserEntity = UserEntity{
 		{
 			Item:   actionGetChannel,
 			Weight: 56,
+		},
+		{
+			Item:   actionGetTeamUnreads,
+			Weight: 41,
 		},
 		{
 			Item:   actionAutocompleteChannel,


### PR DESCRIPTION
Based on the pre-release logs over 7 days, we had:

* /api/v4/channels/TOKEN/posts - 79,077
* /api/v4/users/me/teams/unread - 57,902

I assumed `/api/v4/channels/TOKEN/posts` occurs as often as the `getChannel` action at 56. So I produced the weight of 41 by using (57902/79077)*56.

I'm not sure if that's entirely accurate as I'm not sure what the 56 is based off originally. Thoughts?