### PR TITLE
MM-10483: more profile queries

### DIFF
--- a/loadtest/client_timing_stats.go
+++ b/loadtest/client_timing_stats.go
@@ -94,9 +94,14 @@ func (s *RouteStats) CalcResults() {
 		s.Min, _ = stats.Min(s.Duration)
 		s.Mean, _ = stats.Mean(s.Duration)
 		s.Median, _ = stats.Median(s.Duration)
+		s.InterQuartileRange, _ = stats.InterQuartileRange(s.Duration)
+	}
+
+	// github.com/montanaflynn/stats has an odd implementation of Percentile that fails to
+	// handle small datasets. Avoid NaN for now.
+	if len(s.Duration) > 2 {
 		s.Percentile90, _ = stats.Percentile(s.Duration, 90)
 		s.Percentile95, _ = stats.Percentile(s.Duration, 95)
-		s.InterQuartileRange, _ = stats.InterQuartileRange(s.Duration)
 	}
 }
 

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -28,7 +28,9 @@ type UserEntitiesConfiguration struct {
 	UploadImageChance                 float64
 	LinkPreviewChance                 float64
 	CustomEmojiChance                 float64
+	NeedsProfilesByIdChance           float64
 	NeedsProfilesByUsernameChance     float64
+	NeedsProfileStatusChance          float64
 	DoStatusPolling                   bool
 	RandomizeEntitySelection          bool
 }

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -28,7 +28,7 @@ type UserEntitiesConfiguration struct {
 	UploadImageChance                 float64
 	LinkPreviewChance                 float64
 	CustomEmojiChance                 float64
-	NeedsProfilesChance               float64
+	NeedsProfilesByUsernameChance     float64
 	DoStatusPolling                   bool
 	RandomizeEntitySelection          bool
 }

--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -247,6 +247,20 @@ func actionGetChannel(c *EntityConfig) {
 		mlog.Error("Unable to get channel member.", mlog.String("channel_id", channelId), mlog.String("username", c.UserData.Username), mlog.Err(resp.Error))
 	}
 
+	// The webapp is observed to invoke ViewChannel once without a PrevChannelId, and once with
+	// one specified. Duplicate that behaviour here.
+	prevChannel := team.PickChannel()
+	if prevChannel != nil {
+		prevChannelId := c.ChannelMap[team.Name][prevChannel.Name]
+
+		if _, resp := c.Client.ViewChannel("me", &model.ChannelView{
+			ChannelId:     channelId,
+			PrevChannelId: prevChannelId,
+		}); resp.Error != nil {
+			mlog.Error("Unable to view channel.", mlog.String("channel_id", channelId), mlog.String("prev_channel_id", prevChannelId), mlog.String("username", c.UserData.Username))
+		}
+	}
+
 	if posts, resp := c.Client.GetPostsForChannel(channelId, 0, 60, ""); resp.Error != nil {
 		mlog.Error("Unable to get channel member.", mlog.String("channel_id", channelId), mlog.String("username", c.UserData.Username), mlog.Err(resp.Error))
 	} else {

--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -303,6 +303,17 @@ func actionGetChannel(c *EntityConfig) {
 		}
 	}
 
+	usersToQueryById := make([]string, 0)
+	for rand.Float64() < c.LoadTestConfig.UserEntitiesConfiguration.NeedsProfilesByIdChance {
+		nextUser := "user" + strconv.Itoa(rand.Intn(c.LoadTestConfig.LoadtestEnviromentConfig.NumUsers))
+		usersToQueryById = append(usersToQueryById, nextUser)
+	}
+	if len(usersToQueryById) > 0 {
+		if _, resp := c.Client.GetUsersByIds(usersToQueryById); resp.Error != nil {
+			mlog.Error("Unable to get users by ids", mlog.Err(resp.Error))
+		}
+	}
+
 	usersToQueryByUsername := make([]string, 0)
 	for rand.Float64() < c.LoadTestConfig.UserEntitiesConfiguration.NeedsProfilesByUsernameChance {
 		if rand.Float64() > 0.5 {
@@ -316,6 +327,17 @@ func actionGetChannel(c *EntityConfig) {
 	if len(usersToQueryByUsername) > 0 {
 		if _, resp := c.Client.GetUsersByUsernames(usersToQueryByUsername); resp.Error != nil {
 			mlog.Error("Unable to get users by usernames", mlog.Err(resp.Error))
+		}
+	}
+
+	usersToQueryForStatusById := make([]string, 0)
+	for rand.Float64() < c.LoadTestConfig.UserEntitiesConfiguration.NeedsProfileStatusChance {
+		nextUser := "user" + strconv.Itoa(rand.Intn(c.LoadTestConfig.LoadtestEnviromentConfig.NumUsers))
+		usersToQueryForStatusById = append(usersToQueryForStatusById, nextUser)
+	}
+	if len(usersToQueryForStatusById) > 0 {
+		if _, resp := c.Client.GetUsersStatusesByIds(usersToQueryForStatusById); resp.Error != nil {
+			mlog.Error("Unable to get user statuses by ids", mlog.Err(resp.Error))
 		}
 	}
 }

--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -450,9 +450,9 @@ func actionPostWebhook(c *EntityConfig) {
 }
 
 func actionGetTeamUnreads(c *EntityConfig) {
-	_, err := c.Client.GetTeamsUnreadForUser("me", "")
-	if err != nil {
-		mlog.Error("Failed to get team unreads", mlog.String("user", c.UserData.Username))
+	_, response := c.Client.GetTeamsUnreadForUser("me", "")
+	if response.Error != nil {
+		mlog.Error("Failed to get team unreads", mlog.String("user", c.UserData.Username), mlog.Err(response.Error))
 	}
 }
 

--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -288,18 +288,19 @@ func actionGetChannel(c *EntityConfig) {
 			}
 		}
 	}
-	usersToQuery := make([]string, 0)
-	for rand.Float64() < c.LoadTestConfig.UserEntitiesConfiguration.NeedsProfilesChance {
+
+	usersToQueryByUsername := make([]string, 0)
+	for rand.Float64() < c.LoadTestConfig.UserEntitiesConfiguration.NeedsProfilesByUsernameChance {
 		if rand.Float64() > 0.5 {
 			nextUser := "user" + strconv.Itoa(rand.Intn(c.LoadTestConfig.LoadtestEnviromentConfig.NumUsers))
-			usersToQuery = append(usersToQuery, nextUser)
+			usersToQueryByUsername = append(usersToQueryByUsername, nextUser)
 		} else {
 			nextUser := model.NewId()
-			usersToQuery = append(usersToQuery, nextUser)
+			usersToQueryByUsername = append(usersToQueryByUsername, nextUser)
 		}
 	}
-	if len(usersToQuery) > 0 {
-		if _, resp := c.Client.GetUsersByUsernames(usersToQuery); resp.Error != nil {
+	if len(usersToQueryByUsername) > 0 {
+		if _, resp := c.Client.GetUsersByUsernames(usersToQueryByUsername); resp.Error != nil {
 			mlog.Error("Unable to get users by usernames", mlog.Err(resp.Error))
 		}
 	}

--- a/loadtestconfig.default.json
+++ b/loadtestconfig.default.json
@@ -61,7 +61,7 @@
         "UploadImageChance": 0.01,
         "LinkPreviewChance": 0.2,
         "CustomEmojiChance": 0.2,
-        "NeedsProfilesChance": 0.38,
+        "NeedsProfilesByUsernameChance": 0.38,
         "DoStatusPolling": true,
         "RandomizeEntitySelection": false
     },

--- a/loadtestconfig.default.json
+++ b/loadtestconfig.default.json
@@ -62,6 +62,8 @@
         "LinkPreviewChance": 0.2,
         "CustomEmojiChance": 0.2,
         "NeedsProfilesByUsernameChance": 0.38,
+        "NeedsProfilesByIdChance": 0.22,
+        "NeedsProfileStatusChance": 0.80,
         "DoStatusPolling": true,
         "RandomizeEntitySelection": false
     },

--- a/terraform/cluster_deploy.go
+++ b/terraform/cluster_deploy.go
@@ -330,6 +330,7 @@ func deployToAppInstance(mattermostDistribution, license io.Reader, instanceAddr
 		".ServiceSettings.LicenseFileLocation":         remoteLicenseFilePath,
 		".ServiceSettings.SiteURL":                     clust.SiteURL(),
 		".ServiceSettings.EnableAPIv3":                 true,
+		".ServiceSettings.EnableLinkPreviews":          true,
 		".SqlSettings.DriverName":                      "mysql",
 		".SqlSettings.DataSource":                      clust.DBConnectionString(),
 		".SqlSettings.DataSourceReplicas":              clust.DBReaderConnectionStrings(),


### PR DESCRIPTION
Apart from adding `/api/v4/users(ids|statuses)` to the get posts for a channel call, this also fixes link previews for open graph queries on Terraform, eliminates spurious logs from `GetTeamsUnreadForUser`, and works around a `NaN` issue with github.com/mantanaflynn/stats.

As noted in the commit, over last 7 days:
    /api/v4/channels/TOKEN/posts: 77,524
    /api/v4/users/status/ids: 610,054
    /api/v4/users/ids: 17,043

Unfortunately, it looks like entities also call `/api/v4/users/status/ids` periodically when
polling for user statuses (something we already model in the loadtests). At least in the loadtest,
this accounts for the vast majority of the calls to the status endpoint.

So for /api/v4/users/status/ids, I've just added a fractional chance of also calling this endpoint
as part of querying channel, using no real heuristics to arrive at a useful number. (I picked 80%,
tested repeatedly until it fails, based on a observation of switching channels on pre-release.)

For /api/v4/users/ids, I picked a percentage of 22%, again repeated to make this a lower bound.