### PR TITLE
MM-11944: Varying channel types

### DIFF
--- a/loadtest/bulkload.go
+++ b/loadtest/bulkload.go
@@ -245,7 +245,7 @@ func generateTeams(numTeams int, percentCustomSchemeTeams float64, teamSchemes *
 		teams = append(teams, TeamImportData{
 			Name:            "loadtestteam" + strconv.Itoa(teamNum),
 			DisplayName:     "Loadtest Team " + strconv.Itoa(teamNum),
-			Type:            "O",
+			Type:            model.TEAM_OPEN,
 			Description:     "This is loadtest team " + strconv.Itoa(teamNum),
 			AllowOpenInvite: true,
 			Scheme:          scheme,
@@ -351,7 +351,7 @@ func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFile
 				Team:        "loadtestteam" + strconv.Itoa(teamNum),
 				Name:        "loadtestchannel" + strconv.Itoa(channelNum),
 				DisplayName: "Loadtest Channel " + strconv.Itoa(channelNum),
-				Type:        "O",
+				Type:        model.CHANNEL_OPEN,
 				Header:      "Hea: This is loadtest channel " + strconv.Itoa(teamNum) + " on team " + strconv.Itoa(teamNum),
 				Purpose:     "Pur: This is loadtest channel " + strconv.Itoa(teamNum) + " on team " + strconv.Itoa(teamNum),
 				Scheme:      scheme,

--- a/loadtest/bulkload.go
+++ b/loadtest/bulkload.go
@@ -352,8 +352,8 @@ func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFile
 				Name:        "loadtestchannel" + strconv.Itoa(channelNum),
 				DisplayName: "Loadtest Channel " + strconv.Itoa(channelNum),
 				Type:        model.CHANNEL_OPEN,
-				Header:      "Hea: This is loadtest channel " + strconv.Itoa(teamNum) + " on team " + strconv.Itoa(teamNum),
-				Purpose:     "Pur: This is loadtest channel " + strconv.Itoa(teamNum) + " on team " + strconv.Itoa(teamNum),
+				Header:      "Hea: This is loadtest channel " + strconv.Itoa(channelNum) + " on team " + strconv.Itoa(teamNum),
+				Purpose:     "Pur: This is loadtest channel " + strconv.Itoa(channelNum) + " on team " + strconv.Itoa(teamNum),
 				Scheme:      scheme,
 			})
 			channelsByTeam[teamNum] = append(channelsByTeam[teamNum], len(channels)-1)

--- a/loadtest/bulkload.go
+++ b/loadtest/bulkload.go
@@ -461,11 +461,6 @@ func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFile
 	doneChan := make(chan struct{})
 
 	var output bytes.Buffer
-
-	/*f, err := os.OpenFile("loadtestbulkload.json", os.O_RDWR|os.O_CREATE, 0755)
-	if err != nil {
-		fmt.Println("Problem opening file: " + err.Error())
-	}*/
 	go func() {
 		jenc := json.NewEncoder(&output)
 		for lineObject := range lineObjectsChan {

--- a/loadtest/bulkload.go
+++ b/loadtest/bulkload.go
@@ -338,6 +338,22 @@ func generateEmoji(numEmoji int) []EmojiImportData {
 	return emojis
 }
 
+func makeChannelName(channelNumber int) string {
+	return strings.Join(strings.Fields(fake.WordsN(2)), "-") + "-loadtestchannel" + strconv.Itoa(channelNumber)
+}
+
+func makeChannelDisplayName(channelNumber int) string {
+	return fake.WordsN(2) + " Loadtest Channel " + strconv.Itoa(channelNumber)
+}
+
+func makeChannelHeader() string {
+	return fake.Sentence()
+}
+
+func makeChannelPurpose() string {
+	return fake.Sentence()
+}
+
 // makeDirectChannels creates the requested number of direct message channels.
 func makeDirectChannels(config *LoadtestEnviromentConfig, r *rand.Rand, users []UserImportData) []DirectChannelImportData {
 	// Constrain the requested number of direct message channels to the maximum possible given
@@ -358,7 +374,7 @@ func makeDirectChannels(config *LoadtestEnviromentConfig, r *rand.Rand, users []
 		i := n - 2 - int(math.Floor(math.Sqrt(float64(-8*k+4*n*(n-1)-7))/2.0-0.5))
 		j := k + i + 1 - n*(n-1)/2 + (n-i)*((n-i)-1)/2
 
-		header := "Hea: This is a direct message loadtest channel"
+		header := makeChannelHeader()
 		members := []string{
 			users[i].Username,
 			users[j].Username,
@@ -432,7 +448,7 @@ func makeGroupChannels(config *LoadtestEnviromentConfig, r *rand.Rand, users []U
 			count++
 		}
 
-		header := "Hea: This is a group message loadtest channel"
+		header := makeChannelHeader()
 		members, err := pickRandomUsernames(count)
 		if err != nil {
 			mlog.Warn("failed to pick random usernames for group message channel", mlog.Int("count_group_message_channels", len(groupChannels)), mlog.Err(err))
@@ -451,6 +467,8 @@ func makeGroupChannels(config *LoadtestEnviromentConfig, r *rand.Rand, users []U
 }
 
 func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFileResult {
+	r := rand.New(rand.NewSource(29))
+
 	users := make([]UserImportData, 0, config.NumUsers)
 
 	totalChannelsPerTeam := config.NumChannelsPerTeam + config.NumPrivateChannelsPerTeam
@@ -482,11 +500,11 @@ func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFile
 
 			channels = append(channels, ChannelImportData{
 				Team:        teamName,
-				Name:        "loadtestchannel" + strconv.Itoa(channelNum),
-				DisplayName: "Loadtest Channel " + strconv.Itoa(channelNum),
+				Name:        makeChannelName(channelNum),
+				DisplayName: makeChannelDisplayName(channelNum),
 				Type:        channelType,
-				Header:      "Hea: This is loadtest channel " + strconv.Itoa(channelNum) + " on team " + strconv.Itoa(teamNum),
-				Purpose:     "Pur: This is loadtest channel " + strconv.Itoa(channelNum) + " on team " + strconv.Itoa(teamNum),
+				Header:      makeChannelHeader(),
+				Purpose:     makeChannelPurpose(),
 				Scheme:      scheme,
 			})
 			channelsByTeam[teamNum] = append(channelsByTeam[teamNum], len(channels)-1)
@@ -508,8 +526,6 @@ func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFile
 	numUsersInHighVolumeTeam := int(math.Floor(float64(config.NumUsers) * config.PercentUsersHighVolumeTeams))
 	numUsersInMidVolumeTeam := int(math.Floor(float64(config.NumUsers) * config.PercentUsersMidVolumeTeams))
 	numUsersInLowVolumeTeam := int(math.Floor(float64(config.NumUsers) * config.PercentUsersLowVolumeTeams))
-
-	r := rand.New(rand.NewSource(29))
 
 	teamPermutation := r.Perm(len(teams))
 	for sequenceNum, teamNum := range teamPermutation {

--- a/loadtestconfig.default.json
+++ b/loadtestconfig.default.json
@@ -24,6 +24,7 @@
         "NumTeams": 1,
         "NumChannelsPerTeam": 300,
         "NumPrivateChannelsPerTeam": 100,
+        "NumDirectMessageChannels": 2000,
         "NumUsers": 1000,
         "NumChannelSchemes": 1,
         "NumTeamSchemes": 1,

--- a/loadtestconfig.default.json
+++ b/loadtestconfig.default.json
@@ -22,7 +22,8 @@
     },
     "LoadtestEnviromentConfig": {
         "NumTeams": 1,
-        "NumChannelsPerTeam": 400,
+        "NumChannelsPerTeam": 300,
+        "NumPrivateChannelsPerTeam": 100,
         "NumUsers": 1000,
         "NumChannelSchemes": 1,
         "NumTeamSchemes": 1,

--- a/loadtestconfig.default.json
+++ b/loadtestconfig.default.json
@@ -25,6 +25,7 @@
         "NumChannelsPerTeam": 300,
         "NumPrivateChannelsPerTeam": 100,
         "NumDirectMessageChannels": 2000,
+        "NumGroupMessageChannels": 50,
         "NumUsers": 1000,
         "NumChannelSchemes": 1,
         "NumTeamSchemes": 1,


### PR DESCRIPTION
In addition to the public channels created today, also generate private, direct message and group message channels.

The changes to private are straight forward. Generating direct messages in a randomized way was implemented by shuffling over the upper-right triangle in a matrix of users. Generating group messages this way is less tractable, so a more randomized w/ retry approach is taken instead, on the assumption that group messages in general occur far less frequently.