### PR TITLE
update ports and bump image

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -205,7 +205,7 @@ pipeline {
 
                         ltops destroy -c ${BRANCH}-${BUILD_NUMBER} || echo 0
 
-                        kubectl delete --all deploy,svc,pod,configmap,secrets,statefulset
+                        kubectl delete --all deploy,svc,pod,statefulset
                         '''
                     }
                 }

--- a/ci/loadtest-helm-config.yaml
+++ b/ci/loadtest-helm-config.yaml
@@ -82,14 +82,14 @@ mattermostApp:
   replicaCount: 2
   image:
     repository: mattermost/mattermost-enterprise-edition
-    tag: 5.2.1
+    tag: 5.3.1
     pullPolicy: Always
 
   service:
     name: mattermost-app
     type: ClusterIP
-    externalPort: 8065
-    internalPort: 8065
+    externalPort: 8000
+    internalPort: 8000
     metricsPort: 8067
     clusterPort: 8075
     gossipPort: 8074


### PR DESCRIPTION
Because we are using the mattermost-docker image and it requires the port 8000