### PR TITLE
Add load tests for user search API

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -38,6 +38,11 @@ var tests []TestItem = []TestItem{
 		Test:      &loadtest.TestSearch,
 	},
 	{
+		Name:      "search-users",
+		ShortDesc: "Test search users",
+		Test:      &loadtest.TestSearchUsers,
+	},
+	{
 		Name:      "getchannel",
 		ShortDesc: "Test get channel",
 		Test:      &loadtest.TestGetChannel,

--- a/loadtest/bulkload.go
+++ b/loadtest/bulkload.go
@@ -338,6 +338,10 @@ func generateEmoji(numEmoji int) []EmojiImportData {
 	return emojis
 }
 
+func makeUserName(userNumber int) string {
+	return strings.ToLower(fake.UserName()) + "-" + strconv.Itoa(userNumber)
+}
+
 func makeChannelName(channelNumber int) string {
 	return strings.Join(strings.Fields(fake.WordsN(2)), "-") + "-loadtestchannel" + strconv.Itoa(channelNumber)
 }
@@ -513,12 +517,22 @@ func GenerateBulkloadFile(config *LoadtestEnviromentConfig) GenerateBulkloadFile
 	}
 
 	for userNum := 0; userNum < config.NumUsers; userNum++ {
-		users = append(users, UserImportData{
-			Username: "user" + strconv.Itoa(userNum),
+		user := UserImportData{
+			Username: makeUserName(userNum),
 			Roles:    "system_user",
+			// email is fixed pattern, must match loginAsUsers()
 			Email:    "success+user" + strconv.Itoa(userNum) + "@simulator.amazonses.com",
 			Password: "Loadtestpassword1",
-		})
+		}
+		// give 30% of users a name and/or nickname
+		if r.Intn(10) < 3 {
+			user.FirstName = fake.FirstName()
+			user.LastName = fake.LastName()
+		}
+		if r.Intn(10) < 3 {
+			user.Nickname = fake.Word()
+		}
+		users = append(users, user)
 	}
 
 	numHighVolumeTeams := int(math.Floor(float64(config.NumTeams) * config.PercentHighVolumeTeams))


### PR DESCRIPTION
Adds some tests for the /users/search API.

This also updates the random users that are created, so that the username are random, and first/last/nickname are populated. The previous logic of having all the usernames like "userNNN" meant
that searches for prefixes like "u" would match all users.

See for more info: https://github.com/mattermost/mattermost-server/pull/9782