### PR TITLE
Final tweaks before handoff

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -61,7 +61,7 @@ Note that the Kubernetes cluster does not yet support the `--config` flag to cus
 
 To generate a markdown summary of the loadtest results:
 ```
-ltparse results --file $HOME/.mattermost-load-test-ops/myloadtestcluster/results/*.txt --display markdown
+ltparse results --file $HOME/.mattermost-load-test-ops/cluster-name/results/*.txt --display markdown
 ```
 
 Consult [loadtest.md](loadtest.md#Results) for more details.

--- a/docs/loadtest.md
+++ b/docs/loadtest.md
@@ -42,12 +42,12 @@ Provided the `ltops` command stays running, loadtest logs against a cluster name
 
 To generate a textual summary:
 ```
-ltparse results --file $HOME/.mattermost-load-test-ops/myloadtestcluster/results/*.txt --display text
+ltparse results --file $HOME/.mattermost-load-test-ops/cluster-name/results/*.txt --display text
 ```
 
 To generate a markdown summary:
 ```
-ltparse results --file $HOME~/.mattermost-load-test-ops/myloadtestcluster/results/*.txt --display markdown
+ltparse results --file $HOME~/.mattermost-load-test-ops/cluster-name/results/*.txt --display markdown
 ```
 
 To aggregate results from multiple test runs:
@@ -57,7 +57,7 @@ cat /path/to/results/1 /path/to/results/2 /path/to/results/3 | ltparse results -
 
 To generate a markdown summary comparing the results with a previous results file representing a baseline:
 ```
-ltparse results --file $HOME/.mattermost-load-test-ops/myloadtestcluster/results --display markdown --baseline /path/to/baseline/results
+ltparse results --file $HOME/.mattermost-load-test-ops/cluster-name/results --display markdown --baseline /path/to/baseline/results
 ```
 
 Examining the individual API results. A successful loadtest has low error rates (below 1%), otherwise the system was likely overloaded during the load test. Timing will vary based on the configuration parameters, network setup and infrastructure, but should be within your target threshold to be considered successful.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,7 +78,7 @@ The optional `--config` flag supports a local file path to customize your loadte
 
 To generate a markdown summary of the loadtest results:
 ```
-ltparse results --file $HOME/.mattermost-load-test-ops/myloadtestcluster/results/*.txt --display markdown
+ltparse results --file $HOME/.mattermost-load-test-ops/cluster-name/results/*.txt --display markdown
 ```
 
 Consult [loadtest.md#Results] for more details.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -81,7 +81,7 @@ To generate a markdown summary of the loadtest results:
 ltparse results --file $HOME/.mattermost-load-test-ops/cluster-name/results/*.txt --display markdown
 ```
 
-Consult [loadtest.md#Results] for more details.
+Consult [loadtest.md](loadtest.md#Results) for more details.
 
 ## Debugging your loadtest cluster
 

--- a/loadtest/tests.go
+++ b/loadtest/tests.go
@@ -466,7 +466,7 @@ func actionPostWebhook(c *EntityConfig) {
 			return
 		}
 
-		webhook, resp := c.Client.CreateIncomingWebhook(&model.IncomingWebhook{
+		webhook, resp := c.AdminClient.CreateIncomingWebhook(&model.IncomingWebhook{
 			ChannelId:   channelId,
 			DisplayName: model.NewId(),
 			Description: model.NewId(),


### PR DESCRIPTION
In preparing to handoff this tool to the new platform team, I ran through the documentation and loadtests to fix a few issues. The only major change is the switch to using the admin client to create the incoming webhooks instead of leaving the user clients to do this. @jwilander and I discussed, and think that perhaps this "used to work", but with the switchover to more granular permissions, the defaults may have changed. What I can't yet explain is why it still /sometimes/ works without these changes.