### PR TITLE
MM-16040: Stop relying on DEPRECATED_DO_NOT_USE_EnableOnlyAdminIntegrations

### DIFF
--- a/loadtest/setup_server.go
+++ b/loadtest/setup_server.go
@@ -254,14 +254,19 @@ func checkConfigForLoadtests(adminClient *model.Client4) error {
 	} else {
 		newPermission := []string{}
 		newPermission = append(newPermission, role.Permissions...)
-	OUTER:
+
 		for _, value := range []string{model.PERMISSION_MANAGE_INCOMING_WEBHOOKS.Id,
 			model.PERMISSION_MANAGE_OUTGOING_WEBHOOKS.Id,
 			model.PERMISSION_MANAGE_SLASH_COMMANDS.Id} {
+			found := false
 			for _, permission := range role.Permissions {
 				if permission == value {
-					continue OUTER
+					found = true
+					break
 				}
+			}
+			if found {
+				continue
 			}
 			newPermission = append(newPermission, value)
 		}


### PR DESCRIPTION
Replaced DEPRECATED_DO_NOT_USE_EnableOnlyAdminIntegrations with Role patch

Fixes: https://mattermost.atlassian.net/browse/MM-16040