### PR TITLE
Add backslash to fix shell command in terraform.md

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -56,7 +56,7 @@ Deploy Mattermost, the Nginx proxy and the `loadtest` tool to prepare for runnin
 ltops deploy \
     --cluster cluster-name \
     --mattermost master \
-    --license $HOME/mylicence.mattermost-license 
+    --license $HOME/mylicence.mattermost-license \
     --loadtests master
 ```
 


### PR DESCRIPTION
Pretty trivial change but it took me more than a couple of minutes to figure out that was the reason `ltops loadtest` was failing :stuck_out_tongue_winking_eye: 