### PR TITLE
Change wg.Done sentences to start using defer

### DIFF
--- a/kubernetes/cluster_loadtest.go
+++ b/kubernetes/cluster_loadtest.go
@@ -147,6 +147,7 @@ func (c *Cluster) Loadtest(options *ltops.LoadTestOptions) error {
 	for i, pod := range loadtestPods {
 		pod := pod
 		go func() {
+			defer wg.Done()
 			var err error
 			if i == 0 {
 				err = c.loadtestPod(pod, options.ResultsWriter)
@@ -156,7 +157,6 @@ func (c *Cluster) Loadtest(options *ltops.LoadTestOptions) error {
 			if err != nil {
 				log.Error(err)
 			}
-			wg.Done()
 		}()
 		// Give some time between instances just to avoid any races
 		time.Sleep(time.Second * 10)

--- a/loadtest/bulkload.go
+++ b/loadtest/bulkload.go
@@ -889,8 +889,8 @@ func LoadPosts(cfg *LoadTestConfig, driverName, dataSource string) {
 		for i := 0; i < 4; i++ {
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				importCSVToSQL(csvLines, db)
-				wg.Done()
 			}()
 		}
 

--- a/loadtest/thread_split.go
+++ b/loadtest/thread_split.go
@@ -12,6 +12,7 @@ func ThreadSplit(arrayLen int, numThreads int, action func(int)) {
 	wg.Add(numThreads)
 	for threadNum := 0; threadNum < numThreads; threadNum++ {
 		go func(threadNum int) {
+			defer wg.Done()
 			var end int
 			if threadNum == numThreads-1 {
 				end = arrayLen
@@ -22,7 +23,6 @@ func ThreadSplit(arrayLen int, numThreads int, action func(int)) {
 			for i := start; i < end; i++ {
 				action(i)
 			}
-			wg.Done()
 		}(threadNum)
 	}
 	wg.Wait()

--- a/terraform/cluster_loadtest.go
+++ b/terraform/cluster_loadtest.go
@@ -98,11 +98,11 @@ func (c *Cluster) Loadtest(options *ltops.LoadTestOptions) error {
 		addr := addr
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			logger := logrus.StandardLogger().WithField("instance", addr)
 			if err = c.loadtestInstance(logger, addr, instanceNum, configFile); err != nil {
 				logrus.Error(err)
 			}
-			wg.Done()
 		}()
 	}
 

--- a/terraform/environment.go
+++ b/terraform/environment.go
@@ -116,8 +116,8 @@ func getCmdOutputAndLog(cmd *exec.Cmd) ([]byte, error) {
 	wg.Add(1)
 
 	go func() {
+		defer wg.Done()
 		_, errStdout = io.Copy(stdout, stdoutIn)
-		wg.Done()
 	}()
 
 	_, errStderr = io.Copy(stderr, stderrIn)


### PR DESCRIPTION
For multiples reasons:

- Is safer
- We can add more exit clauses without risk
- Doesn't have performance footprint since version 1.14

(Thank you @agnivade for those points)